### PR TITLE
Add ability to specify a Stylesheet when rendering to reStructuredText

### DIFF
--- a/nvpy/nvpy-example.cfg
+++ b/nvpy/nvpy-example.cfg
@@ -42,3 +42,9 @@ notes_as_txt = 0
 # uncomment this to disable simplenote sync altogether
 # default is to sync with simplenote
 #simplenote_sync = 0
+
+# uncomment this to override the default reStructuredText stylesheet with one of
+# your own css files.  Note that this is only useful when you are rendering a
+# reStructuredText (reST) note to HTML.
+#rest_css_path = /path/to/my/stylesheet.css
+


### PR DESCRIPTION
Rendering a note written in reStructuredText is a nice feature but
the default stylesheet, the one included in docutils, is not likely to
suit everyone's needs.  This commit enables the user to specify a
stylesheet to use when rendering the reST formatted note.  It adds one
new configuration parameter, rest_css_path, the full path to the
user's stylesheet.  The stylesheet is embedded into the reST-rendered
page.  Customizing the stylesheet allows users to do customizations
that enhance the notes.  My motivation for this change was to enable
the use of 'strikethrough' text on list items that have been
completed.
