### PR TITLE
Fixed unicode filenames

### DIFF
--- a/nvpy/notes_db.py
+++ b/nvpy/notes_db.py
@@ -46,8 +46,8 @@ class NotesDB(utils.SubjectMixin):
         now = time.time()    
         # now read all .json files from disk
         fnlist = glob.glob(self.helper_key_to_fname('*'))
-        txtlist = glob.glob(self.config.txt_path + '/*.txt')
-        txtlist += glob.glob(self.config.txt_path + '/*.mkdn')
+        txtlist = glob.glob(unicode(self.config.txt_path + '/*.txt', 'utf-8'))
+        txtlist += glob.glob(unicode(self.config.txt_path + '/*.mkdn', 'utf-8'))
 
         # removing json files and force full full sync if using text files
         # and none exists and json files are there

--- a/nvpy/nvpy-example.cfg
+++ b/nvpy/nvpy-example.cfg
@@ -36,7 +36,7 @@ search_tags = 1
 # default: no
 notes_as_txt = 0
 
-# txt notes direcory relative to home
+# txt notes directory relative to home
 #txt_path = Notes2
 
 # uncomment this to disable simplenote sync altogether

--- a/nvpy/utils.py
+++ b/nvpy/utils.py
@@ -34,6 +34,11 @@ def get_note_title_file(note):
         if not fn:
             return ''
 
+        if isinstance(fn, str):
+            fn = unicode(fn, 'utf-8')
+        else:
+            fn = unicode(fn)
+
         if note_markdown(note):
             fn += '.mkdn'
         else:


### PR DESCRIPTION
- Fix for unicode characters in text note filename.
- typo in nvpy-example.cfg
