### PR TITLE
Improvement to search behaviour

### DIFF
--- a/nvpy/view.py
+++ b/nvpy/view.py
@@ -864,7 +864,7 @@ class View(utils.SubjectMixin):
         
         edit_menu.add_command(label="Find", accelerator="Ctrl+F",
                               underline=0, command=lambda: self.search_entry.focus())
-        self.root.bind_all("<Control-f>", lambda e: self.search_entry.focus())
+        self.root.bind_all("<Control-f>", self.search)
 
         # TOOLS ########################################################
         tools_menu = tk.Menu(menu, tearoff=False)
@@ -1411,6 +1411,9 @@ class View(utils.SubjectMixin):
         self.mute('change:tags')
         self.mute('change:pinned')
 
+    def search(self,e):
+        self.search_entry.focus()
+        self.search_entry.selection_range(0,tk.END)
 
     def set_cs(self, cs, silent=False):
         if silent:


### PR DESCRIPTION
I thought it would be nice to follow the behavior of Firefox et al and select the previously typed search query when pressing ctrl-f.

This means that you can just start typing to erase the previous search and start a new one, while not really making editing the search query any harder.

Thank you for a handy program!
