### PR TITLE
Quote string in install command example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ nvPY works best on Python 2.7.x. It does not work on Python 3.x yet.
 
 To install the latest development version from github, do::
 
-    pip install git+https://github.com/cpbotha/nvpy.git#egg=nvpy
+    pip install 'git+https://github.com/cpbotha/nvpy.git#egg=nvpy'
 
 OR, to install the version currently on pypi, do::
 


### PR DESCRIPTION
zsh doesn't like it unquoted:

`zsh: no matches found: git+https://github.com/cpbotha/nvpy.git#egg=nvpy`