### PR TITLE
Added re.MULTILINE to filter_notes_regexp to allow multiline regexp sear...

### DIFF
--- a/nvpy/notes_db.py
+++ b/nvpy/notes_db.py
@@ -36,20 +36,20 @@ class NotesDB(utils.SubjectMixin):
     """
     def __init__(self, config):
         utils.SubjectMixin.__init__(self)
-        
+
         self.config = config
-        
+
         # create db dir if it does not exist
         if not os.path.exists(config.db_path):
             os.mkdir(config.db_path)
-            
+
         self.db_path = config.db_path
 
         # create txt Notes dir if it does not exist
         if self.config.notes_as_txt and not os.path.exists(config.txt_path):
             os.mkdir(config.txt_path)
-        
-        now = time.time()    
+
+        now = time.time()
         # now read all .json files from disk
         fnlist = glob.glob(self.helper_key_to_fname('*'))
         txtlist = glob.glob(unicode(self.config.txt_path + '/*.txt', 'utf-8'))
@@ -78,7 +78,7 @@ class NotesDB(utils.SubjectMixin):
                         txtlist.remove(tfn)
                         if os.path.getmtime(tfn) > os.path.getmtime(fn):
                             logging.debug('Text note was changed: %s' % (fn,))
-                            with codecs.open(tfn, mode='rb', encoding='utf-8') as f:  
+                            with codecs.open(tfn, mode='rb', encoding='utf-8') as f:
                                 c = f.read()
 
                             n['content'] = c
@@ -108,13 +108,13 @@ class NotesDB(utils.SubjectMixin):
                 # these notes have just been read, so at this moment
                 # they're in sync with the disc.
                 n['savedate'] = now
-        
+
         if self.config.notes_as_txt:
             for fn in txtlist:
                 logging.debug('New text note found : %s' % (fn),)
                 tfn = os.path.join(self.config.txt_path, fn)
                 try:
-                    with codecs.open(tfn, mode='rb', encoding='utf-8') as f:  
+                    with codecs.open(tfn, mode='rb', encoding='utf-8') as f:
                         c = f.read()
 
                 except IOError, e:
@@ -146,12 +146,12 @@ class NotesDB(utils.SubjectMixin):
         # this does not yet need network access
         if self.config.simplenote_sync:
             self.simplenote = Simplenote(config.sn_username, config.sn_password)
-        
+
             # we'll use this to store which notes are currently being synced by
             # the background thread, so we don't add them anew if they're still
             # in progress. This variable is only used by the background thread.
             self.threaded_syncing_keys = {}
-        
+
             # reading a variable or setting this variable is atomic
             # so sync thread will write to it, main thread will only
             # check it sometimes.
@@ -159,20 +159,20 @@ class NotesDB(utils.SubjectMixin):
 
             self.q_sync = Queue()
             self.q_sync_res = Queue()
-        
+
             thread_sync = Thread(target=self.worker_sync)
             thread_sync.setDaemon(True)
             thread_sync.start()
-        
+
     def create_note(self, title):
         # need to get a key unique to this database. not really important
         # what it is, as long as it's unique.
         new_key = utils.generate_random_key()
         while new_key in self.notes:
             new_key = utils.generate_random_key()
-            
+
         timestamp = time.time()
-            
+
         # note has no internal key yet.
         new_note = {
                     'content' : title,
@@ -182,11 +182,11 @@ class NotesDB(utils.SubjectMixin):
                     'syncdate' : 0, # never been synced with server
                     'tags' : []
                     }
-        
+
         self.notes[new_key] = new_note
-        
+
         return new_key
-    
+
     def delete_note(self, key):
         n = self.notes[key]
         n['deleted'] = 1
@@ -344,19 +344,19 @@ class NotesDB(utils.SubjectMixin):
 
 
     def filter_notes_regexp(self, search_string=None):
-        """Return list of notes filtered with search_string, 
-        a regular expression, each a tuple with (local_key, note). 
+        """Return list of notes filtered with search_string,
+        a regular expression, each a tuple with (local_key, note).
         """
 
         if search_string:
             try:
                 if self.config.case_sensitive == 0:
-                    sspat = re.compile(search_string, re.I)
+                    sspat = re.compile(search_string, re.I|re.MULTILINE)
                 else:
-                    sspat = re.compile(search_string)
+                    sspat = re.compile(search_string,re.MULTILINE)
             except re.error:
                 sspat = None
-            
+
         else:
             sspat = None
 
@@ -408,36 +408,36 @@ class NotesDB(utils.SubjectMixin):
 
     def get_note_content(self, key):
         return self.notes[key].get('content')
-    
+
     def get_note_status(self, key):
         n = self.notes[key]
         o = utils.KeyValueObject(saved=False, synced=False, modified=False)
         modifydate = float(n['modifydate'])
         savedate = float(n['savedate'])
-        
+
         if savedate > modifydate:
             o.saved = True
         else:
             o.modified = True
-            
+
         if float(n['syncdate']) > modifydate:
             o.synced = True
-            
+
         return o
 
     def get_save_queue_len(self):
         return self.q_save.qsize()
 
-            
+
     def get_sync_queue_len(self):
         return self.q_sync.qsize()
-        
+
     def helper_key_to_fname(self, k):
             return os.path.join(self.db_path, k) + '.json'
-    
+
     def helper_save_note(self, k, note):
         """Save a single note to disc.
-        
+
         """
 
         if self.config.notes_as_txt:
@@ -458,13 +458,13 @@ class NotesDB(utils.SubjectMixin):
                 self.titlelist[k] = t
                 fn = os.path.join(self.config.txt_path, t)
                 try:
-                    with codecs.open(fn, mode='wb', encoding='utf-8') as f:  
+                    with codecs.open(fn, mode='wb', encoding='utf-8') as f:
                         c = note.get('content')
                         if isinstance(c, str):
                             c = unicode(c, 'utf-8')
                         else:
                             c = unicode(c)
-                        
+
                         f.write(c)
                 except IOError, e:
                     logging.error('NotesDB_save: Error opening %s: %s' % (fn, str(e)))
@@ -479,7 +479,7 @@ class NotesDB(utils.SubjectMixin):
                 if os.path.isfile(dfn):
                     logging.debug('Delete file %s ' % (dfn, ))
                     os.unlink(dfn)
-        
+
         fn = self.helper_key_to_fname(k)
         if not self.config.simplenote_sync and note.get('deleted'):
             if os.path.isfile(fn):
@@ -489,65 +489,65 @@ class NotesDB(utils.SubjectMixin):
 
         # record that we saved this to disc.
         note['savedate'] = time.time()
-        
+
     def sync_note_unthreaded(self, k):
         """Sync a single note with the server.
 
-        Update existing note in memory with the returned data.  
+        Update existing note in memory with the returned data.
         This is a sychronous (blocking) call.
         """
 
         note = self.notes[k]
-        
+
         if not note.get('key') or float(note.get('modifydate')) > float(note.get('syncdate')):
-            # if has no key, or it has been modified sync last sync, 
+            # if has no key, or it has been modified sync last sync,
             # update to server
             uret = self.simplenote.update_note(note)
 
             if uret[1] == 0:
                 # success!
                 n = uret[0]
-        
+
                 # if content was unchanged, there'll be no content sent back!
                 if n.get('content', None):
                     new_content = True
-        
+
                 else:
                     new_content = False
-                    
+
                 now = time.time()
                 # 1. store when we've synced
                 n['syncdate'] = now
-                
+
                 # update our existing note in-place!
                 note.update(n)
-        
+
                 # return the key
                 return (k, new_content)
-                
+
             else:
                 return None
 
-            
+
         else:
             # our note is synced up, but we check if server has something new for us
             gret = self.simplenote.get_note(note['key'])
-            
+
             if gret[1] == 0:
                 n = gret[0]
-                
+
                 if int(n.get('syncnum')) > int(note.get('syncnum')):
                     n['syncdate'] = time.time()
                     note.update(n)
                     return (k, True)
-                
+
                 else:
                     return (k, False)
 
             else:
                 return None
 
-        
+
     def save_threaded(self):
         for k,n in self.notes.items():
             savedate = float(n.get('savedate'))
@@ -557,47 +557,47 @@ class NotesDB(utils.SubjectMixin):
                 # put it on my queue as a save
                 o = utils.KeyValueObject(action=ACTION_SAVE, key=k, note=cn)
                 self.q_save.put(o)
-                
+
         # in this same call, we process stuff that might have been put on the result queue
         nsaved = 0
         something_in_queue = True
         while something_in_queue:
             try:
                 o = self.q_save_res.get_nowait()
-                
+
             except Empty:
                 something_in_queue = False
-                
+
             else:
                 # o (.action, .key, .note) is something that was written to disk
                 # we only record the savedate.
                 self.notes[o.key]['savedate'] = o.note['savedate']
                 self.notify_observers('change:note-status', utils.KeyValueObject(what='savedate',key=o.key))
                 nsaved += 1
-                
+
         return nsaved
-        
-    
+
+
     def sync_to_server_threaded(self, wait_for_idle=True):
         """Only sync notes that have been changed / created locally since previous sync.
-        
+
         This function is called by the housekeeping handler, so once every
         few seconds.
-        
+
         @param wait_for_idle: Usually, last modification date has to be more
         than a few seconds ago before a sync to server is attempted. If
         wait_for_idle is set to False, no waiting is applied. Used by exit
         cleanup in controller.
-        
+
         """
-        
+
         # this many seconds of idle time (i.e. modification this long ago)
         # before we try to sync.
         if wait_for_idle:
             lastmod = 3
         else:
             lastmod = 0
-        
+
         now = time.time()
         for k,n in self.notes.items():
             # if note has been modified sinc the sync, we need to sync.
@@ -618,7 +618,7 @@ class NotesDB(utils.SubjectMixin):
                 # put it on my queue as a sync
                 o = utils.KeyValueObject(action=ACTION_SYNC_PARTIAL_TO_SERVER, key=k, note=cn)
                 self.q_sync.put(o)
-                
+
         # in this same call, we read out the result queue
         nsynced = 0
         nerrored = 0
@@ -626,16 +626,16 @@ class NotesDB(utils.SubjectMixin):
         while something_in_queue:
             try:
                 o = self.q_sync_res.get_nowait()
-                
+
             except Empty:
                 something_in_queue = False
-                
+
             else:
                 okey = o.key
 
                 if o.error:
                     nerrored += 1
-                    
+
                 else:
                     # o (.action, .key, .note) is something that was synced
 
@@ -644,7 +644,7 @@ class NotesDB(utils.SubjectMixin):
                     # running a full sync whilst the worker thread is putting
                     # results in the queue.
                     if float(o.note['syncdate']) > float(self.notes[okey]['syncdate']):
-                                        
+
                         if float(o.note['syncdate']) > float(self.notes[okey]['modifydate']):
                             # note was synced AFTER the last modification to our local version
                             # do an in-place update of the existing note
@@ -653,7 +653,7 @@ class NotesDB(utils.SubjectMixin):
                             self.notes[okey].update(o.note)
                             # notify anyone (probably nvPY) that this note has been changed
                             self.notify_observers('synced:note', utils.KeyValueObject(lkey=okey, old_note=old_note))
-                            
+
                         else:
                             # the user has changed stuff since the version that got synced
                             # just record syncnum and version that we got from simplenote
@@ -667,25 +667,25 @@ class NotesDB(utils.SubjectMixin):
                             tkeys = ['syncnum', 'version', 'syncdate', 'key']
                             for tk in tkeys:
                                 self.notes[okey][tk] = o.note[tk]
-                            
+
                         nsynced += 1
                         self.notify_observers('change:note-status', utils.KeyValueObject(what='syncdate',key=okey))
-                    
+
                 # after having handled the note that just came back,
                 # we can take it from this blocker dict
                 del self.threaded_syncing_keys[okey]
 
         return (nsynced, nerrored)
-    
-    
+
+
     def sync_full(self):
         """Perform a full bi-directional sync with server.
-        
+
         This follows the recipe in the SimpleNote 2.0 API documentation.
         After this, it could be that local keys have been changed, so
         reset any views that you might have.
         """
-        
+
         local_updates = {}
         local_deletes = {}
         now = time.time()
@@ -706,32 +706,32 @@ class NotesDB(utils.SubjectMixin):
                     n.update(uret[0])
                     # and put it at the new key slot
                     self.notes[k] = n
-                    
+
                     # record that we just synced
                     uret[0]['syncdate'] = now
-                    
+
                     # whatever the case may be, k is now updated
                     local_updates[k] = True
                     if lk != k:
                         # if lk was a different (purely local) key, should be deleted
                         local_deletes[lk] = True
-                        
+
                     self.notify_observers('progress:sync_full', utils.KeyValueObject(msg='Synced modified note %d to server.' % (ni,)))
-                        
+
                 else:
                     raise SyncError("Sync step 1 error - Could not update note to server")
-             
+
         # 2. if remote syncnum > local syncnum, update our note; if key is new, add note to local.
         # this gets the FULL note list, even if multiple gets are required
-        self.notify_observers('progress:sync_full', utils.KeyValueObject(msg='Retrieving full note list from server, could take a while.'))       
+        self.notify_observers('progress:sync_full', utils.KeyValueObject(msg='Retrieving full note list from server, could take a while.'))
         nl = self.simplenote.get_note_list()
         if nl[1] == 0:
             nl = nl[0]
             self.notify_observers('progress:sync_full', utils.KeyValueObject(msg='Retrieved full note list from server.'))
-            
+
         else:
             raise SyncError('Could not get note list from server.')
-        
+
         server_keys = {}
         lennl = len(nl)
         sync_from_server_errors = 0
@@ -771,7 +771,7 @@ class NotesDB(utils.SubjectMixin):
                     logging.error('Error syncing new note %s from server: %s' % (k, ret[0]))
                     sync_from_server_errors+=1
 
-        # 3. for each local note not in server index, remove.     
+        # 3. for each local note not in server index, remove.
         for lk in self.notes.keys():
             if lk not in server_keys:
                 if self.config.notes_as_txt:
@@ -780,7 +780,7 @@ class NotesDB(utils.SubjectMixin):
                         os.unlink(tfn)
                 del self.notes[lk]
                 local_deletes[lk] = True
-                
+
         # sync done, now write changes to db_path
         for uk in local_updates.keys():
             try:
@@ -788,7 +788,7 @@ class NotesDB(utils.SubjectMixin):
 
             except WriteError, e:
                 raise WriteError(e)
-            
+
         for dk in local_deletes.keys():
             fn = self.helper_key_to_fname(dk)
             if os.path.exists(fn):
@@ -797,7 +797,7 @@ class NotesDB(utils.SubjectMixin):
         self.notify_observers('progress:sync_full', utils.KeyValueObject(msg='Full sync complete.'))
 
         return sync_from_server_errors
-        
+
     def set_note_content(self, key, content):
         n = self.notes[key]
         old_content = n.get('content')
@@ -848,7 +848,7 @@ class NotesDB(utils.SubjectMixin):
                 except WriteError, e:
                     logging.error('FATAL ERROR in access to file system')
                     print "FATAL ERROR: Check the nvpy.log"
-                    os._exit(1) 
+                    os._exit(1)
 
                 else:
                     # put the whole thing back into the result q
@@ -856,11 +856,11 @@ class NotesDB(utils.SubjectMixin):
                     # is never going to use o again.
                     # somebody has to read out the queue...
                     self.q_save_res.put(o)
-                
+
     def worker_sync(self):
         while True:
             o = self.q_sync.get()
-            
+
             if o.action == ACTION_SYNC_PARTIAL_TO_SERVER:
                 self.waiting_for_simplenote = True
                 if 'key' in o.note:
@@ -868,10 +868,10 @@ class NotesDB(utils.SubjectMixin):
 
                 else:
                     logging.debug('Sending new note (local key %s) to server.' % (o.key,))
-                    
+
                 uret = self.simplenote.update_note(o.note)
                 self.waiting_for_simplenote = False
-                
+
                 if uret[1] == 0:
                     # success!
                     n = uret[0]
@@ -880,24 +880,23 @@ class NotesDB(utils.SubjectMixin):
                         # if note has not been changed, we don't get content back
                         # delete our own copy too.
                         del o.note['content']
-                        
+
                     logging.debug('Server replies with updated note ' + n['key'])
-                        
+
                     # syncdate was set when the note was copied into our queue
                     # we rely on that to determine when a returned note should
                     # overwrite a note in the main list.
-                        
+
                     # store the actual note back into o
                     # in-place update of our existing note copy
                     o.note.update(n)
 
                     # success!
                     o.error = 0
-                    
+
                     # and put it on the result queue
                     self.q_sync_res.put(o)
-                    
+
                 else:
                     o.error = 1
                     self.q_sync_res.put(o)
-                    


### PR DESCRIPTION
There are situations were I wan't to do a regular expression search and match the start of a new line. For example I create todos in my notes by prefixing the lines with "O". Searching for "^O" then gives me all the notes with incompleted todos in.