### PR TITLE
Making `pep8` (mostly) happy

### DIFF
--- a/nvpy/__main__.py
+++ b/nvpy/__main__.py
@@ -1,3 +1,2 @@
 import nvpy
 nvpy.main()
-

--- a/nvpy/nvpy.py
+++ b/nvpy/nvpy.py
@@ -60,6 +60,7 @@ else:
 
 VERSION = "0.9.4"
 
+
 class Config:
     """
     @ivar files_read: list of config files that were parsed.
@@ -74,29 +75,29 @@ class Config:
         # cross-platform way of getting home dir!
         # http://stackoverflow.com/a/4028943/532513
         home = os.path.abspath(os.path.expanduser('~'))
-        defaults = {'app_dir' : app_dir,
-                    'appdir' : app_dir,
-                    'home' : home,
-                    'notes_as_txt' : '0',
-                    'housekeeping_interval' : '2',
-                    'search_mode' : 'gstyle',
-                    'case_sensitive' : '1',
-                    'search_tags' : '1',
-                    'sort_mode' : '1',
-                    'pinned_ontop' : '1',
-                    'db_path' : os.path.join(home, '.nvpy'),
-                    'txt_path' : os.path.join(home, '.nvpy/notes'),
-                    'font_family' : 'Courier', # monospaced on all platforms
-                    'font_size' : '10',
-                    'list_font_family' : 'Helvetica', # sans on all platforms
-                    'list_font_family_fixed' : 'Courier', # monospace on all platforms
-                    'list_font_size' : '10',
-                    'layout' : 'horizontal',
-                    'print_columns' : '0',
-                    'background_color' : 'white',
-                    'sn_username' : '',
-                    'sn_password' : '',
-                    'simplenote_sync' : '1',
+        defaults = {'app_dir': app_dir,
+                    'appdir': app_dir,
+                    'home': home,
+                    'notes_as_txt': '0',
+                    'housekeeping_interval': '2',
+                    'search_mode': 'gstyle',
+                    'case_sensitive': '1',
+                    'search_tags': '1',
+                    'sort_mode': '1',
+                    'pinned_ontop': '1',
+                    'db_path': os.path.join(home, '.nvpy'),
+                    'txt_path': os.path.join(home, '.nvpy/notes'),
+                    'font_family': 'Courier',  # monospaced on all platforms
+                    'font_size': '10',
+                    'list_font_family': 'Helvetica',  # sans on all platforms
+                    'list_font_family_fixed': 'Courier',  # monospace on all platforms
+                    'list_font_size': '10',
+                    'layout': 'horizontal',
+                    'print_columns': '0',
+                    'background_color': 'white',
+                    'sn_username': '',
+                    'sn_password': '',
+                    'simplenote_sync': '1',
                     # Filename or filepath to a css file used style the rendered
                     # output; e.g. nvpy.css or /path/to/my.css
                     'rest_css_path': None,
@@ -172,12 +173,13 @@ class NotesListModel(SubjectMixin):
     def get_idx(self, key):
         """Find idx for passed LOCAL key.
         """
-        found = [i for i,e in enumerate(self.list) if e.key == key]
+        found = [i for i, e in enumerate(self.list) if e.key == key]
         if found:
             return found[0]
 
         else:
             return -1
+
 
 class Controller:
     """Main application class.
@@ -244,13 +246,12 @@ class Controller:
         # read our database of notes into memory
         # and sync with simplenote.
         try:
-           self.notes_db = NotesDB(self.config)
+            self.notes_db = NotesDB(self.config)
 
         except ReadError, e:
             emsg = "Please check nvpy.log.\n" + str(e)
             self.view.show_error('Sync error', emsg)
             exit(1)
-
 
         self.notes_db.add_observer('synced:note', self.observer_notes_db_synced_note)
         self.notes_db.add_observer('change:note-status', self.observer_notes_db_change_note_status)
@@ -381,7 +382,6 @@ class Controller:
         # simply keep that selection!
         self.view.set_search_entry_text(self.view.get_search_entry_text())
 
-
     def helper_markdown_to_html(self):
         if self.selected_note_idx >= 0:
             key = self.notes_list_model.list[self.selected_note_idx].key
@@ -473,12 +473,11 @@ class Controller:
         else:
             syncn = wfsn = 0
 
-        savet = 'Saving %d notes.' % (saven,) if saven > 0 else '';
-        synct = 'Waiting to sync %d notes.' % (syncn,) if syncn > 0 else '';
-        wfsnt = 'Syncing with simplenote server.' if wfsn else '';
+        savet = 'Saving %d notes.' % (saven,) if saven > 0 else ''
+        synct = 'Waiting to sync %d notes.' % (syncn,) if syncn > 0 else ''
+        wfsnt = 'Syncing with simplenote server.' if wfsn else ''
 
         return ' '.join([i for i in [savet, synct, wfsnt] if i])
-
 
     def observer_view_keep_house(self, view, evt_type, evt):
         # queue up all notes that need to be saved
@@ -578,9 +577,6 @@ class Controller:
                 # text changes trigger this)
                 self.view.activate_search_string_highlights()
 
-
-
-
     def observer_view_change_text(self, view, evt_type, evt):
         # get new text and update our database
         # need local key of currently selected note for this
@@ -664,7 +660,6 @@ class Controller:
             self.view.clear_note_ui()
             self.view.set_note_editing(False)
 
-
         self.selected_note_idx = idx
 
         # when we do this, we don't want the change:{text,tags,pinned} events
@@ -704,4 +699,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/nvpy/search_entry.py
+++ b/nvpy/search_entry.py
@@ -1,4 +1,4 @@
-# pretty style for entry widget, adapted from 
+# pretty style for entry widget, adapted from
 # http://python-ttk.googlecode.com/svn/trunk/pyttk-samples/mac_searchentry.py
 
 """Mac style search widget
@@ -53,17 +53,18 @@ otQhBRa6VvSJIRwhIkotvgRTzMUYZ6xxMcj4QkspeKDxxRhEmUfIHWjAgQcijEDissuXvCyz
 zH7Q8YQURxDhUsn/bCInR3AELfTQZBRt9BBJkCGFFVhMwTNBlnBCSCGEIJQQIAklZMXWRBAR
 RRRWENHwRQEBADs="""
 
+
 def make_style():
     # need to keep bindings for s1 and s2 around, else the get eaten by GC
     global s1, s2
     s1 = Tkinter.PhotoImage("search1", data=data, format="gif -index 0")
     s2 = Tkinter.PhotoImage("search2", data=data, format="gif -index 1")
-    
+
     style = ttk.Style()
-    
+
     style.element_create("Search.field", "image", "search1",
         ("focus", "search2"), border=[22, 7, 14], sticky="ew")
-    
+
     style.layout("Search.entry", [
         ("Search.field", {"sticky": "nswe", "border": 1, "children":
             [("Entry.padding", {"sticky": "nswe", "children":
@@ -71,6 +72,5 @@ def make_style():
             })]
         })]
     )
-    
+
     #style.configure("Search.entry", background="#b2b2b2")
-    

--- a/nvpy/simplenote.py
+++ b/nvpy/simplenote.py
@@ -27,6 +27,7 @@ DATA_URL = 'https://simple-note.appspot.com/api2/data'
 INDX_URL = 'https://simple-note.appspot.com/api2/index?'
 NOTE_FETCH_LENGTH = 20
 
+
 class Simplenote(object):
     """ Class for interacting with the simplenote web service """
 
@@ -53,7 +54,7 @@ class Simplenote(object):
         try:
             res = urllib2.urlopen(request).read()
             token = urllib2.quote(res)
-        except IOError: # no connection exception
+        except IOError:  # no connection exception
             token = None
         return token
 
@@ -71,7 +72,6 @@ class Simplenote(object):
             self.token = self.authenticate(self.username, self.password)
         return self.token
 
-
     def get_note(self, noteid):
         """ method to get a specific note
 
@@ -88,7 +88,7 @@ class Simplenote(object):
         # request note
         params = '/%s?auth=%s&email=%s' % (str(noteid), self.get_token(),
                                            self.username)
-        request = Request(DATA_URL+params)
+        request = Request(DATA_URL + params)
         try:
             response = urllib2.urlopen(request)
         except HTTPError, e:
@@ -100,8 +100,8 @@ class Simplenote(object):
         if isinstance(note["content"], str):
             note["content"] = note["content"].encode('utf-8')
 
-        if note.has_key("tags"):
-            note["tags"] = [t.encode('utf-8') if isinstance(t,str) else t for t in note["tags"]]
+        if "tags" in note:
+            note["tags"] = [t.encode('utf-8') if isinstance(t, str) else t for t in note["tags"]]
 
         return note, 0
 
@@ -126,14 +126,14 @@ class Simplenote(object):
         if isinstance(note["content"], str):
             note["content"] = unicode(note["content"], 'utf-8')
 
-        if note.has_key("tags"):
+        if "tags" in note:
             # if a tag is a string, unicode it, otherwise pass it through
             # unchanged (it's unicode already)
             # using the ternary operator, because I like it: a if test else b
             note["tags"] = [unicode(t, 'utf-8') if isinstance(t, str) else t for t in note["tags"]]
 
         # determine whether to create a new note or updated an existing one
-        if note.has_key("key"):
+        if "key" in note:
             url = '%s/%s?auth=%s&email=%s' % (DATA_URL, note["key"],
                                               self.get_token(), self.username)
         else:
@@ -166,7 +166,7 @@ class Simplenote(object):
         """
         if type(note) == str:
             return self.update_note({"content": note})
-        elif (type(note) == dict) and note.has_key("content"):
+        elif (type(note) == dict) and "content" in note:
             return self.update_note(note)
         else:
             return "No string or valid note.", -1
@@ -190,7 +190,7 @@ class Simplenote(object):
         status = 0
         ret = []
         response = {}
-        notes = { "data" : [] }
+        notes = {"data": []}
 
         # get the note index
         if qty < NOTE_FETCH_LENGTH:
@@ -201,14 +201,14 @@ class Simplenote(object):
                                                  NOTE_FETCH_LENGTH)
         # perform initial HTTP request
         try:
-            request = Request(INDX_URL+params)
+            request = Request(INDX_URL + params)
             response = json.loads(urllib2.urlopen(request).read())
             notes["data"].extend(response["data"])
         except IOError:
             status = -1
 
         # get additional notes if bookmark was set in response
-        while response.has_key("mark") and len(notes["data"]) < qty:
+        while "mark" in response and len(notes["data"]) < qty:
             if (qty - len(notes["data"])) < NOTE_FETCH_LENGTH:
                 vals = (self.get_token(), self.username, response["mark"], qty - len(notes["data"]))
             else:
@@ -217,7 +217,7 @@ class Simplenote(object):
 
             # perform the actual HTTP request
             try:
-                request = Request(INDX_URL+params)
+                request = Request(INDX_URL + params)
                 response = json.loads(urllib2.urlopen(request).read())
                 notes["data"].extend(response["data"])
             except IOError:
@@ -270,7 +270,7 @@ class Simplenote(object):
 
         params = '/%s?auth=%s&email=%s' % (str(note_id), self.get_token(),
                                            self.username)
-        request = Request(url=DATA_URL+params, method='DELETE')
+        request = Request(url=DATA_URL + params, method='DELETE')
         try:
             urllib2.urlopen(request)
         except IOError, e:
@@ -293,5 +293,3 @@ class Request(urllib2.Request):
             return self.method
 
         return urllib2.Request.get_method(self)
-
-

--- a/nvpy/tk.py
+++ b/nvpy/tk.py
@@ -2,7 +2,7 @@
 # copyright 2012 by Charl P. Botha <cpbotha@vxlabs.com>
 # new BSD license
 
-# Tkinter and ttk documentation recommend pulling all symbols into client 
+# Tkinter and ttk documentation recommend pulling all symbols into client
 # module namespace. I don't like that, so first pulling into this module
 # tk, then can use tk.whatever in main module.
 

--- a/nvpy/utils.py
+++ b/nvpy/utils.py
@@ -10,13 +10,15 @@ import urllib2
 
 # first line with non-whitespace should be the title
 note_title_re = re.compile('\s*(.*)\n?')
-        
+
+
 def generate_random_key():
     """Generate random 30 digit (15 byte) hex string.
-    
+
     stackoverflow question 2782229
     """
-    return '%030x' % (random.randrange(256**15),)
+    return '%030x' % (random.randrange(256 ** 15),)
+
 
 def get_note_title(note):
     mo = note_title_re.match(note.get('content', ''))
@@ -24,6 +26,7 @@ def get_note_title(note):
         return mo.groups()[0]
     else:
         return ''
+
 
 def get_note_title_file(note):
     mo = note_title_re.match(note.get('content', ''))
@@ -47,6 +50,7 @@ def get_note_title_file(note):
         return fn
     else:
         return ''
+
 
 def human_date(timestamp):
     """
@@ -88,6 +92,7 @@ def note_pinned(n):
     else:
         return 0
 
+
 def note_markdown(n):
     asystags = n.get('systemtags', 0)
     # no systemtag at all
@@ -100,6 +105,8 @@ def note_markdown(n):
         return 0
 
 tags_illegal_chars = re.compile(r'[\s]')
+
+
 def sanitise_tags(tags):
     """
     Given a string containing comma-separated tags, sanitise and return a list of string tags.
@@ -123,7 +130,6 @@ def sanitise_tags(tags):
         return illegals_removed.split(',')
 
 
-
 def sort_by_title_pinned(a, b):
     if note_pinned(a.note) and not note_pinned(b.note):
         return -1
@@ -131,6 +137,7 @@ def sort_by_title_pinned(a, b):
         return 1
     else:
         return cmp(get_note_title(a.note), get_note_title(b.note))
+
 
 def sort_by_modify_date_pinned(a, b):
     if note_pinned(a.note) and not note_pinned(b.note):
@@ -140,32 +147,35 @@ def sort_by_modify_date_pinned(a, b):
     else:
         return cmp(float(a.note.get('modifydate', 0)), float(b.note.get('modifydate', 0)))
 
+
 def check_internet_on():
     """Utility method to check if we have an internet connection.
-    
+
     slightly adapted from: http://stackoverflow.com/a/3764660/532513
     """
     try:
-        urllib2.urlopen('http://74.125.228.100',timeout=1)
+        urllib2.urlopen('http://74.125.228.100', timeout=1)
         return True
-    
-    except urllib2.URLError: 
+
+    except urllib2.URLError:
         pass
-    
-    return False    
+
+    return False
+
 
 class KeyValueObject:
     """Store key=value pairs in this object and retrieve with o.key.
-    
+
     You should also be able to do MiscObject(**your_dict) for the same effect.
     """
 
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
 
+
 class SubjectMixin:
     """Maintain a list of callables for each event type.
-    
+
     We follow the convention action:object, e.g. change:entry.
     """
 
@@ -176,21 +186,21 @@ class SubjectMixin:
     def add_observer(self, evt_type, o):
         if evt_type not in self.observers:
             self.observers[evt_type] = [o]
-        
+
         elif o not in self.observers[evt_type]:
             self.observers[evt_type].append(o)
-        
+
     def notify_observers(self, evt_type, evt):
         if evt_type in self.mutes or evt_type not in self.observers:
             return
-        
+
         for o in self.observers[evt_type]:
             # invoke observers with ourselves as first param
             o(self, evt_type, evt)
-            
+
     def mute(self, evt_type):
         self.mutes[evt_type] = True
-        
+
     def unmute(self, evt_type):
         if evt_type in self.mutes:
             del self.mutes[evt_type]

--- a/nvpy/view.py
+++ b/nvpy/view.py
@@ -16,6 +16,7 @@ import webbrowser
 
 from datetime import datetime
 
+
 class WidgetRedirector:
 
     """Support for redirecting arbitrary widget subcommands."""
@@ -36,15 +37,17 @@ class WidgetRedirector:
     def close(self):
         for name in self.dict.keys():
             self.unregister(name)
-        widget = self.widget; del self.widget
-        orig = self.orig; del self.orig
+        widget = self.widget
+        del self.widget
+        orig = self.orig
+        del self.orig
         tk = widget.tk
         w = widget._w
         tk.deletecommand(w)
         tk.call("rename", orig, w)
 
     def register(self, name, function):
-        if self.dict.has_key(name):
+        if name in self.dict():
             previous = dict[name]
         else:
             previous = OriginalCommand(self, name)
@@ -53,7 +56,7 @@ class WidgetRedirector:
         return previous
 
     def unregister(self, name):
-        if self.dict.has_key(name):
+        if name in self.dict():
             function = self.dict[name]
             del self.dict[name]
             if hasattr(self.widget, name):
@@ -136,7 +139,7 @@ class HelpBindings(tk.Toplevel):
 class StatusBar(tk.Frame):
     """Adapted from the tkinterbook.
     """
-    
+
     # actions
     # global status
     # note status
@@ -152,7 +155,7 @@ class StatusBar(tk.Frame):
     # 0 - saved and synced - light blue - 3
     # 1 - saved - light yellow - 2
     # 2 - modified - lighter red - 1
-    NOTE_STATUS_LUT = {0 : 3, 1 : 2, 2 : 1}
+    NOTE_STATUS_LUT = {0: 3, 1: 2, 2: 1}
 
     def __init__(self, master):
         tk.Frame.__init__(self, master)
@@ -172,7 +175,7 @@ class StatusBar(tk.Frame):
 
     def set_note_status(self, fmt, *args):
         """ *.. .s. .sS
-        """ 
+        """
         self.note_status.config(text=fmt % args)
         self.note_status.update_idletasks()
 
@@ -191,6 +194,7 @@ class StatusBar(tk.Frame):
     def clear_status(self):
         self.status.config(text="")
         self.status.update_idletasks()
+
 
 class NotesList(tk.Frame):
     """
@@ -218,7 +222,7 @@ class NotesList(tk.Frame):
             font=f,
             yscrollcommand=yscrollbar.set,
             undo=True,
-            background = config.background_color)
+            background=config.background_color)
         # change default font at runtime with:
         #text.config(font=f)
 
@@ -254,8 +258,8 @@ class NotesList(tk.Frame):
         # list containing tuples with each note's title, tags,
         self.note_headers = []
 
-        self.layout=config.layout
-        self.print_columns=config.print_columns
+        self.layout = config.layout
+        self.print_columns = config.print_columns
         if bold_font.measure(' ') > f.measure(' '):
             self.cwidth = bold_font.measure(' ')
         else:
@@ -277,18 +281,18 @@ class NotesList(tk.Frame):
 
         if self.layout == "vertical" and self.print_columns == 1:
             nrchars, rem = divmod((self.text.winfo_width()), self.cwidth)
-            cellwidth = (int(nrchars) - 8)/2
-            
+            cellwidth = (int(nrchars) - 8) / 2
+
             if pinned:
                 title += ' *'
 
-            self.text.insert(tk.END, u'{0:<{w}}'.format(title[:cellwidth-1], w=cellwidth), ("title,"))
+            self.text.insert(tk.END, u'{0:<{w}}'.format(title[:cellwidth - 1], w=cellwidth), ("title,"))
 
             if tags > 0:
                 if config.tagfound:
-                    self.text.insert(tk.END, u'{0:<{w}}'.format(','.join(tags)[:cellwidth-1], w=cellwidth), ("found",))
+                    self.text.insert(tk.END, u'{0:<{w}}'.format(','.join(tags)[:cellwidth - 1], w=cellwidth), ("found",))
                 else:
-                    self.text.insert(tk.END, u'{0:<{w}}'.format(','.join(tags)[:cellwidth-1], w=cellwidth), ("tags",))
+                    self.text.insert(tk.END, u'{0:<{w}}'.format(','.join(tags)[:cellwidth - 1], w=cellwidth), ("tags",))
 
             self.text.insert(tk.END, ' ' + utils.human_date(modifydate), ("modifydate",))
 
@@ -312,10 +316,8 @@ class NotesList(tk.Frame):
 
         self.disable_text()
 
-
     def _bind_events(self):
         # Text widget events ##########################################
-
 
         self.text.bind("<Button 1>", self.cmd_text_button1)
 
@@ -349,14 +351,12 @@ class NotesList(tk.Frame):
 
         self.text.bind("<Next>", cmd_pagedown)
 
-
     def cmd_text_button1(self, event):
         # find line that was clicked on
         text_index = self.text.index("@%d,%d" % (event.x, event.y))
         # go from event coordinate to tkinter text INDEX to note idx!
         idx = int(text_index.split('.')[0]) - 1
         self.select(idx, silent=False)
-
 
     def clear(self):
         """
@@ -424,7 +424,7 @@ class NotesList(tk.Frame):
         """
 
         # tkinter text first line is 1, but first column is 0
-        row = idx+1
+        row = idx + 1
         start = "%d.0" % (row,)
         end = "%d.end" % (row,)
 
@@ -477,7 +477,8 @@ class NotesList(tk.Frame):
         elif new_idx < 0:
             self.select(0, silent)
 
-tkinter_umlauts=['odiaeresis', 'adiaeresis', 'udiaeresis', 'Odiaeresis', 'Adiaeresis', 'Udiaeresis', 'ssharp']
+tkinter_umlauts = ['odiaeresis', 'adiaeresis', 'udiaeresis', 'Odiaeresis', 'Adiaeresis', 'Udiaeresis', 'ssharp']
+
 
 class TriggeredcompleteEntry(tk.Entry):
     """
@@ -487,22 +488,22 @@ class TriggeredcompleteEntry(tk.Entry):
     ctrl-space. The first matching tag is shown. The user can either continue
     pressing ctrl-space to see more matching tags, or right arrow to select
     the current suggestion and continue typing. Backspace will delete the
-    suggested part. 
+    suggested part.
 
-    To enable triggeredcompletion use set_completion_list(list) to define 
+    To enable triggeredcompletion use set_completion_list(list) to define
     a list of possible strings to hit.
     To cycle through hits use CTRL <space> keys.
 
     @ivar cycle: if 1, then we're cycling through alternative completions.
     """
 
-    def __init__(self, master, case_sensitive, **kw): 
+    def __init__(self, master, case_sensitive, **kw):
         tk.Entry.__init__(self, master, **kw)
         self.case_sensitive = case_sensitive
         # make sure we're initialised, else the event handler could generate
         # exceptions checking for instance variables that don't exist yet.
         self.set_completion_list([])
-        self.bind('<KeyRelease>', self.handle_keyrelease)               
+        self.bind('<KeyRelease>', self.handle_keyrelease)
 
     def set_completion_list(self, completion_list):
         self._completion_list = completion_list
@@ -515,13 +516,13 @@ class TriggeredcompleteEntry(tk.Entry):
     def triggeredcomplete(self):
         """triggeredcomplete the Entry, delta may be 0/1 to cycle through possible hits"""
 
-        if self.cycle: # need to delete selection otherwise we would fix the current position
+        if self.cycle:  # need to delete selection otherwise we would fix the current position
             self.delete(self.position, tk.END)
             self._hit_index += 1
             if self._hit_index == len(self._hits):
                 self._hit_index = 0
 
-        else: # set position to end so selection starts where textentry ended
+        else:  # set position to end so selection starts where textentry ended
             self.position = len(self.get())
             wstartsc = self.get().rfind(':')
             wstartsp = self.get().rfind(' ')
@@ -535,25 +536,25 @@ class TriggeredcompleteEntry(tk.Entry):
             # collect hits
             _hits = []
             for element in self._completion_list:
-                if self.case_sensitive == 0: 
+                if self.case_sensitive == 0:
                     if element.lower().startswith(self.get()[self.wstart:].lower()):
-                         _hits.append(element)
+                        _hits.append(element)
                 else:
                     if element.startswith(self.get()[self.wstart:]):
-                         _hits.append(element)
+                        _hits.append(element)
 
             self._hit_index = 0
-            self._hits=_hits
+            self._hits = _hits
 
         # now finally perform the triggered completion
         if self._hits:
-            self.delete(self.wstart,tk.END)
-            self.insert(self.wstart,self._hits[self._hit_index])
-            self.select_range(self.position,tk.END)
+            self.delete(self.wstart, tk.END)
+            self.insert(self.wstart, self._hits[self._hit_index])
+            self.select_range(self.position, tk.END)
 
     def handle_keyrelease(self, event):
         """event handler for the keyrelease event on this widget"""
-        ctrl  = ((event.state & 0x0004) != 0)
+        ctrl = ((event.state & 0x0004) != 0)
 
         # special case handling below only if we are in cycle mode.
         if self.cycle:
@@ -563,14 +564,14 @@ class TriggeredcompleteEntry(tk.Entry):
                 self.position = self.index(tk.END)
 
             if event.keysym == "Right":
-                self.position = self.index(tk.END) # go to end (no selection)
+                self.position = self.index(tk.END)  # go to end (no selection)
                 self.cycle = 0
 
             if event.keysym == "Left":
                 self.cycle = 0
 
         if event.keysym == "space" and ctrl:
-            # cycle 
+            # cycle
             self.triggeredcomplete()
             if self.cycle == 0:
                 self.cycle = 1
@@ -579,16 +580,16 @@ class TriggeredcompleteEntry(tk.Entry):
 class View(utils.SubjectMixin):
     """Main user interface class.
     """
-    
+
     def __init__(self, config, notes_list_model):
         utils.SubjectMixin.__init__(self)
-        
+
         self.config = config
         self.taglist = None
-        
+
         notes_list_model.add_observer('set:list', self.observer_notes_list)
         self.notes_list_model = notes_list_model
-        
+
         self.root = None
 
         self._create_ui()
@@ -597,7 +598,7 @@ class View(utils.SubjectMixin):
         # set default font for dialog boxes on Linux
         # on Windows, tkinter uses system dialogs in any case
         self.root.option_add('*Dialog.msg.font', 'Helvetica 12')
-        
+
         self.text_tags_links = []
         self.text_tags_search = []
 
@@ -608,15 +609,15 @@ class View(utils.SubjectMixin):
 
     def askyesno(self, title, msg):
         return tkMessageBox.askyesno(title, msg)
-    
+
     def cmd_notes_list_select(self, evt):
         sidx = self.notes_list.selected_idx
         self.notify_observers('select:note', utils.KeyValueObject(sel=sidx))
-        
+
     def cmd_root_delete(self, evt=None):
         sidx = self.notes_list.selected_idx
         self.notify_observers('delete:note', utils.KeyValueObject(sel=sidx))
-        
+
     def cmd_root_new(self, evt=None):
         # this'll get caught by a controller event handler
         self.notify_observers('create:note', utils.KeyValueObject(title=self.get_search_entry_text()))
@@ -663,21 +664,21 @@ class View(utils.SubjectMixin):
         # we need to get rid of newline that text adds automatically
         # at end.
         return self.text_note.get(1.0, "end-1c")
-    
+
     def get_search_entry_text(self):
         return self.search_entry_var.get()
-    
+
     def refresh_notes_list(self):
         """Trigger a complete refresh notes list by resetting search entry.
         """
         # store cursor position first! returns e.g. 8.32
         #cursor_pos = self.text_note.index(tk.INSERT)
-        
+
         # since 0.6, set_search_entry() tries to leave the currently selected
         # note untouched if it still exists in the newly returned list
         # so we don't have to do an explicit reselect.
         self.set_search_entry_text(self.get_search_entry_text())
-        
+
         #self.text_note.mark_set(tk.INSERT, cursor_pos)
 
     def see_first_search_instance(self):
@@ -709,7 +710,7 @@ class View(utils.SubjectMixin):
     def set_note_status(self, status):
         """status is an object with ivars modified, saved and synced.
         """
-        
+
         if status.modified:
             s = 'modified'
             self.statusbar.set_note_status_color(2)
@@ -722,15 +723,15 @@ class View(utils.SubjectMixin):
         else:
             s = 'synced'
             self.statusbar.set_note_status_color(0)
-        
+
         self.statusbar.set_note_status('Current note %s' % (s,))
 
     def set_note_tally(self, filtered_notes, active_notes, total_notes):
         self.statusbar.set_centre_status('Listing %d / %d active notes (%d total)' % (filtered_notes, active_notes, total_notes))
-            
+
     def set_search_entry_text(self, text):
         self.search_entry_var.set(text)
-        
+
     def _bind_events(self):
         # make sure window close also goes through our handler
         self.root.protocol('WM_DELETE_WINDOW', self.handler_close)
@@ -746,7 +747,7 @@ class View(utils.SubjectMixin):
         # if nothing is selected, try to create new note with
         # search entry value as name
         self.notes_list.text.bind("<Return>", self.handler_search_enter)
-        
+
         self.search_entry.bind("<Escape>", lambda e:
                 self.search_entry.delete(0, tk.END))
         self.search_entry.bind("<Control-bracketleft>", lambda e:
@@ -754,7 +755,7 @@ class View(utils.SubjectMixin):
         # this will either focus current content, or
         # if there's no selection, create a new note.
         self.search_entry.bind("<Return>", self.handler_search_enter)
-        
+
         self.search_entry.bind("<Up>", lambda e:
             self.notes_list.select_prev(silent=False))
         self.search_entry.bind("<Control-k>", lambda e:
@@ -770,12 +771,12 @@ class View(utils.SubjectMixin):
             self.notes_list.select_next(silent=False, delta=10))
 
         self.text_note.bind("<<Change>>", self.handler_text_change)
-        
+
         # user presses escape in text area, they go back to notes list
         self.text_note.bind("<Escape>", lambda e: self.notes_list.text.focus())
         self.text_note.bind("<Control-bracketleft>", lambda e: self.notes_list.text.focus())
         # <Key>
-        
+
         self.text_note.bind("<Control-a>", self.cmd_select_all)
 
         self.tags_entry_var.trace('w', self.handler_tags_entry)
@@ -790,39 +791,35 @@ class View(utils.SubjectMixin):
 
         Called by _create_ui.
         """
-        
+
         # MAIN MENU ####################################################
         menu = tk.Menu(self.root)
         self.root.config(menu=menu)
 
         file_menu = tk.Menu(menu, tearoff=False)
         menu.add_cascade(label="File", underline='0', menu=file_menu)
-        
-        
-        
-        
 
         # FILE ##########################################################
-        file_menu.add_command(label = "New note", underline=0,
+        file_menu.add_command(label="New note", underline=0,
                               command=self.cmd_root_new, accelerator="Ctrl+N")
         self.root.bind_all("<Control-n>", self.cmd_root_new)
 
-        file_menu.add_command(label = "Delete note", underline=0,
-                              command=self.cmd_root_delete, accelerator="Ctrl+D")        
+        file_menu.add_command(label="Delete note", underline=0,
+                              command=self.cmd_root_delete, accelerator="Ctrl+D")
         self.root.bind_all("<Control-d>", self.cmd_root_delete)
-        
+
         file_menu.add_separator()
-        
-        file_menu.add_command(label = "Sync full", underline=5,
+
+        file_menu.add_command(label="Sync full", underline=5,
                               command=self.cmd_sync_full)
-        file_menu.add_command(label = "Sync current note",
+        file_menu.add_command(label="Sync current note",
                 underline=0, command=self.cmd_sync_current_note,
                 accelerator="Ctrl+S")
         self.root.bind_all("<Control-s>", self.cmd_sync_current_note)
-        
+
         file_menu.add_separator()
 
-        file_menu.add_command(label = "Render Markdown to HTML", underline=7,
+        file_menu.add_command(label="Render Markdown to HTML", underline=7,
                 command=self.cmd_markdown, accelerator="Ctrl+M")
         self.root.bind_all("<Control-m>", self.cmd_markdown)
 
@@ -832,31 +829,30 @@ class View(utils.SubjectMixin):
                 onvalue=True, offvalue=False,
                 variable=self.continuous_rendering)
 
-        file_menu.add_command(label = "Render reST to HTML", underline=7,
+        file_menu.add_command(label="Render reST to HTML", underline=7,
                 command=self.cmd_rest, accelerator="Ctrl+R")
         self.root.bind_all("<Control-r>", self.cmd_rest)
-        
+
         file_menu.add_separator()
 
-        file_menu.add_command(label = "Exit", underline=1,
+        file_menu.add_command(label="Exit", underline=1,
                               command=self.handler_close, accelerator="Ctrl+Q")
         self.root.bind_all("<Control-q>", self.handler_close)
 
         # EDIT ##########################################################
         edit_menu = tk.Menu(menu, tearoff=False)
         menu.add_cascade(label="Edit", underline=0, menu=edit_menu)
-        
+
         edit_menu.add_command(label="Undo", accelerator="Ctrl+Z",
                               underline=0, command=lambda: self.text_note.edit_undo())
         self.root.bind_all("<Control-z>", lambda e: self.text_note.edit_undo())
-        
+
         edit_menu.add_command(label="Redo", accelerator="Ctrl+Y",
                               underline=0, command=lambda: self.text_note.edit_undo())
         self.root.bind_all("<Control-y>", lambda e: self.text_note.edit_redo())
-                
-        
+
         edit_menu.add_separator()
-        
+
         edit_menu.add_command(label="Cut", accelerator="Ctrl+X",
                               underline=2, command=self.cmd_cut)
         edit_menu.add_command(label="Copy", accelerator="Ctrl+C",
@@ -870,7 +866,7 @@ class View(utils.SubjectMixin):
         # better binding for select all then?
 
         edit_menu.add_separator()
-        
+
         edit_menu.add_command(label="Find", accelerator="Ctrl+F",
                               underline=0, command=lambda: self.search_entry.focus())
         self.root.bind_all("<Control-f>", self.search)
@@ -890,20 +886,19 @@ class View(utils.SubjectMixin):
         help_menu = tk.Menu(menu, tearoff=False)
         menu.add_cascade(label="Help", underline='0', menu=help_menu)
 
-        help_menu.add_command(label = "About", underline = 0,
-                              command = self.cmd_help_about)
-        help_menu.add_command(label = "Bindings", underline = 0,
-                              command = self.cmd_help_bindings,
+        help_menu.add_command(label="About", underline=0,
+                              command=self.cmd_help_about)
+        help_menu.add_command(label="Bindings", underline=0,
+                              command=self.cmd_help_bindings,
                               accelerator="Ctrl+?")
-
 
         # END MENU ######################################################
 
     def _create_ui(self):
 
         # these two variables determine the final dimensions of our interface
-        #FRAME_HEIGHT=400
-        TEXT_WIDTH=80
+        #FRAME_HEIGHT = 400
+        TEXT_WIDTH = 80
 
         # set the correct class name. this helps your desktop environment
         # to identify the nvPY window.
@@ -936,13 +931,13 @@ class View(utils.SubjectMixin):
         self.statusbar.pack(fill=tk.X, side=tk.BOTTOM, padx=3, pady=3)
 
         search_frame = tk.Frame(self.root)
-        
+
         search_entry.make_style()
         self.search_entry_var = tk.StringVar()
         self.search_entry = TriggeredcompleteEntry(search_frame, self.config.case_sensitive, textvariable=self.search_entry_var, style="Search.entry")
         self.search_entry_var.trace('w', self.handler_search_entry)
 
-        cs_label = tk.Label(search_frame,text="CS ")
+        cs_label = tk.Label(search_frame, text="CS ")
         self.cs_checkbutton_var = tk.IntVar()
         cs_checkbutton = tk.Checkbutton(search_frame, variable=self.cs_checkbutton_var)
         self.cs_checkbutton_var.trace('w', self.handler_cs_checkbutton)
@@ -958,18 +953,16 @@ class View(utils.SubjectMixin):
         self.search_mode_cb.pack(side=tk.RIGHT, padx=5)
         cs_checkbutton.pack(side=tk.RIGHT)
         cs_label.pack(side=tk.RIGHT)
-        self.search_entry.pack(fill=tk.X,padx=5, pady=5)
-
+        self.search_entry.pack(fill=tk.X, padx=5, pady=5)
 
         search_frame.pack(side=tk.TOP, fill=tk.X)
-        
-        
+
         # the paned window ##############################################
-        
+
         if self.config.layout == "horizontal":
             paned_window = tk.PanedWindow(self.root, orient=tk.HORIZONTAL)
             paned_window.pack(fill=tk.BOTH, expand=1)
-            
+
             list_frame = tk.Frame(paned_window, width=100)
             paned_window.add(list_frame)
 
@@ -987,16 +980,15 @@ class View(utils.SubjectMixin):
         else:
             paned_window = tk.PanedWindow(self.root, orient=tk.VERTICAL)
             paned_window.pack(fill=tk.BOTH, expand=1)
-            
+
             list_frame = tk.Frame(paned_window, height=150)
             list_frame.pack_propagate(0)
             paned_window.add(list_frame)
 
             if self.config.print_columns == 1:
-                font_family=self.config.list_font_family_fixed
-
+                font_family = self.config.list_font_family_fixed
             else:
-                font_family=self.config.list_font_family
+                font_family = self.config.list_font_family
 
             self.notes_list = NotesList(
                 list_frame,
@@ -1014,7 +1006,7 @@ class View(utils.SubjectMixin):
         note_meta_frame = tk.Frame(note_frame)
         note_meta_frame.pack(side=tk.BOTTOM, fill=tk.X)
 
-        pinned_label = tk.Label(note_meta_frame,text="Pinned")
+        pinned_label = tk.Label(note_meta_frame, text="Pinned")
         pinned_label.pack(side=tk.LEFT)
         self.pinned_checkbutton_var = tk.IntVar()
         self.pinned_checkbutton = tk.Checkbutton(note_meta_frame, variable=self.pinned_checkbutton_var)
@@ -1025,7 +1017,6 @@ class View(utils.SubjectMixin):
         self.tags_entry_var = tk.StringVar()
         self.tags_entry = tk.Entry(note_meta_frame, textvariable=self.tags_entry_var)
         self.tags_entry.pack(side=tk.LEFT, fill=tk.X, expand=1, pady=3, padx=3)
-
 
         # we'll use this method to create the different edit boxes
         def create_scrolled_text(master):
@@ -1042,19 +1033,17 @@ class View(utils.SubjectMixin):
                                   font=f, tabs=(4 * f.measure(0), 'left'), tabstyle='wordprocessor',
                                   yscrollcommand=yscrollbar.set,
                                   undo=True,
-                                  background = self.config.background_color)
+                                  background=self.config.background_color)
             # change default font at runtime with:
             text.config(font=f)
 
             # need expand=1 so that when user resizes window, text widget gets the extra space
             text.pack(fill=tk.BOTH, expand=1)
 
-
             #xscrollbar.config(command=text.xview)
             yscrollbar.config(command=text.yview)
 
             return text
-
 
         # setup user_text ###############################################
         self.text_note = create_scrolled_text(note_frame)
@@ -1064,7 +1053,7 @@ class View(utils.SubjectMixin):
 
         # now set the minsize so that things can not disappear
         self.root.minsize(self.root.winfo_width(), self.root.winfo_height())
-        
+
         # call update so we know that sizes are up to date
         self.root.update_idletasks()
 
@@ -1109,7 +1098,7 @@ class View(utils.SubjectMixin):
         if silent:
             self.mute_note_data_changes()
 
-        self.text_note.delete(1.0, tk.END) # clear all
+        self.text_note.delete(1.0, tk.END)  # clear all
         self.text_note.insert(1.0, msg)
         self.tags_entry_var.set('')
 
@@ -1117,11 +1106,11 @@ class View(utils.SubjectMixin):
 
         if silent:
             self.unmute_note_data_changes()
-        
+
     def close(self):
         """Programmatically close application windows.
-        
-        Called by controller. 
+
+        Called by controller.
         """
         self.root.destroy()
 
@@ -1133,10 +1122,9 @@ class View(utils.SubjectMixin):
 
     def cmd_markdown(self, event=None):
         self.notify_observers('command:markdown', None)
-        
+
     def cmd_paste(self):
         self.text_note.event_generate('<<Paste>>')
-
 
     def cmd_help_about(self):
 
@@ -1145,7 +1133,7 @@ class View(utils.SubjectMixin):
             'nvPY %s is copyright 2012 by Charl P. Botha '
             '<http://charlbotha.com/>\n\n'
             'A rather ugly but cross-platform simplenote client.' % (self.config.app_version,),
-            parent = self.root)
+            parent=self.root)
 
     def cmd_help_bindings(self):
         h = HelpBindings()
@@ -1156,7 +1144,7 @@ class View(utils.SubjectMixin):
 
     def cmd_sync_current_note(self, event=None):
         self.notify_observers('command:sync_current_note', None)
-        
+
     def cmd_sync_full(self, event=None):
         self.notify_observers('command:sync_full', None)
 
@@ -1171,13 +1159,13 @@ class View(utils.SubjectMixin):
     def handler_housekeeper(self):
         # nvPY will do saving and syncing!
         self.notify_observers('keep:house', None)
-        
+
         # check if titles need refreshing
         refresh_notes_list = False
         prev_title = None
         prev_modifydate = None
         prev_pinned = 0
-        for i,o in enumerate(self.notes_list_model.list):
+        for i, o in enumerate(self.notes_list_model.list):
             # order should be the same as our listbox
             nt = utils.get_note_title(o.note)
             ot = self.notes_list.get_title(i)
@@ -1220,9 +1208,9 @@ class View(utils.SubjectMixin):
                     logging.debug("alpha resort triggered")
                     refresh_notes_list = True
                     break
-                
+
                 prev_title = nt
-                
+
             else:
 
                 # we go from top to bottom, newest to oldest
@@ -1233,16 +1221,16 @@ class View(utils.SubjectMixin):
                     logging.debug("modifydate resort triggered")
                     refresh_notes_list = True
                     break
-                
+
                 prev_modifydate = md
                 if self.config.pinned_ontop:
                     prev_pinned = utils.note_pinned(o.note)
-            
+
         if refresh_notes_list:
             self.refresh_notes_list()
-        
+
         self.root.after(self.config.housekeeping_interval_ms, self.handler_housekeeper)
-        
+
     def handler_pinned_checkbutton(self, *args):
         self.notify_observers('change:pinned',
             utils.KeyValueObject(value=self.pinned_checkbutton_var.get()))
@@ -1255,13 +1243,13 @@ class View(utils.SubjectMixin):
         if self.notes_list.selected_idx >= 0:
             self.text_note.focus()
             self.text_note.see(tk.INSERT)
-            
+
         else:
             # nothing selected
             self.notify_observers('create:note', utils.KeyValueObject(title=self.get_search_entry_text()))
             # the note will be created synchronously, so we can focus the text area already
             self.text_note.focus()
-        
+
     def handler_search_entry(self, *args):
         self.notify_observers('change:entry',
                               utils.KeyValueObject(value=self.search_entry_var.get()))
@@ -1279,7 +1267,6 @@ class View(utils.SubjectMixin):
         self.notify_observers('change:search_mode',
             utils.KeyValueObject(value=self.search_mode_var.get()))
 
-
     def handler_tags_entry(self, *args):
         self.notify_observers('change:tags',
             utils.KeyValueObject(value=self.tags_entry_var.get()))
@@ -1291,24 +1278,24 @@ class View(utils.SubjectMixin):
 
         else:
             webbrowser.open(link)
-            
+
     def activate_search_string_highlights(self):
         # no note selected, so no highlights.
         if self.notes_list.selected_idx < 0:
             return
 
         t = self.text_note
-        
+
         # remove all existing tags
         for tag in self.text_tags_search:
             t.tag_remove(tag, '1.0', 'end')
-        
+
         del self.text_tags_search[:]
-        
+
         st = self.notes_list_model.match_regexp
         if not st:
             return
-        
+
         # take care of invalid regular expressions...
         try:
             if self.config.case_sensitive == 0:
@@ -1318,7 +1305,7 @@ class View(utils.SubjectMixin):
 
         except re.error:
             return
-        
+
         for mo in pat.finditer(t.get('1.0', 'end')):
 
             # start creating a new tkinter text tag
@@ -1331,8 +1318,6 @@ class View(utils.SubjectMixin):
 
             # record the tag name so we can delete it later
             self.text_tags_search.append(tag)
-            
-        
 
     def activate_links(self):
         """
@@ -1340,7 +1325,6 @@ class View(utils.SubjectMixin):
         http://www.regexguru.com/2008/11/detecting-urls-in-a-block-of-text/
         (mine is slightly modified)
         """
-
 
         t = self.text_note
         # the last group matches [[bla bla]] inter-note links
@@ -1352,8 +1336,8 @@ class View(utils.SubjectMixin):
             t.tag_remove(tag, '1.0', 'end')
 
         del self.text_tags_links[:]
-        
-        for mo in re.finditer(pat,t.get('1.0', 'end')):
+
+        for mo in re.finditer(pat, t.get('1.0', 'end')):
             # extract the link from the match object
             if mo.groups()[2] is not None:
                 link = mo.groups()[2]
@@ -1366,9 +1350,9 @@ class View(utils.SubjectMixin):
             tag = 'web-%d' % (len(self.text_tags_links),)
             t.tag_config(tag, foreground="blue", underline=ul)
             # hovering should give us the finger (cursor) hehe
-            t.tag_bind(tag, '<Enter>', 
+            t.tag_bind(tag, '<Enter>',
                     lambda e: t.config(cursor="hand2"))
-            t.tag_bind(tag, '<Leave>', 
+            t.tag_bind(tag, '<Leave>',
                     lambda e: t.config(cursor=""))
             # and clicking on it should do something sensible
             t.tag_bind(tag, '<Button-1>', lambda e, link=link:
@@ -1380,7 +1364,6 @@ class View(utils.SubjectMixin):
 
             # record the tag name so we can delete it later
             self.text_tags_links.append(tag)
-
 
     def handler_text_change(self, evt):
         self.notify_observers('change:text', None)
@@ -1411,7 +1394,7 @@ class View(utils.SubjectMixin):
         if evt_type == 'set:list':
             # re-render!
             self.set_notes(notes_list_model.list)
-            
+
     def main_loop(self):
         self.root.mainloop()
 
@@ -1420,9 +1403,9 @@ class View(utils.SubjectMixin):
         self.mute('change:tags')
         self.mute('change:pinned')
 
-    def search(self,e):
+    def search(self, e):
         self.search_entry.focus()
-        self.search_entry.selection_range(0,tk.END)
+        self.search_entry.selection_range(0, tk.END)
 
     def set_cs(self, cs, silent=False):
         if silent:
@@ -1446,16 +1429,16 @@ class View(utils.SubjectMixin):
         self.search_mode_var.set(search_mode)
 
         self.unmute('change:search_mode')
-        
+
     def set_status_text(self, txt):
         self.statusbar.set_status(txt)
-        
+
     def set_note_data(self, note, reset_undo=True, content_unchanged=False):
         """Replace text in editor with content.
-        
+
         This is usually called when a new note is selected (case 1), or
         when a modified note comes back from the server (case 2).
-        
+
         @param reset_undo: Set to False if you don't want to have the undo
         buffer to reset.
         @param content_unchanged: Set to True if you know that the content
@@ -1463,14 +1446,14 @@ class View(utils.SubjectMixin):
         """
 
         if not content_unchanged:
-            self.text_note.delete(1.0, tk.END) # clear all
+            self.text_note.delete(1.0, tk.END)  # clear all
 
         if note is not None:
             if not content_unchanged:
                 self.text_note.insert(tk.END, note['content'])
 
             # default to an empty array for tags
-            tags=note.get('tags', [])
+            tags = note.get('tags', [])
             self.tags_entry_var.set(','.join(tags))
             self.pinned_checkbutton_var.set(utils.note_pinned(note))
 
@@ -1479,8 +1462,7 @@ class View(utils.SubjectMixin):
             # undo buffer, so that a user can't undo right into the previously
             # selected note.
             self.text_note.edit_reset()
-        
-        
+
     def set_notes(self, notes):
         # this method is called by View.observer_notes_list()
 
@@ -1504,15 +1486,14 @@ class View(utils.SubjectMixin):
             # only set completion list if the new combined taglist is larger.
             taglist = list(set(self.taglist + taglist))
             if len(taglist) > len(self.taglist):
-                self.taglist=taglist
+                self.taglist = taglist
                 self.search_entry.set_completion_list(self.taglist)
-
 
     def show_error(self, title, msg):
         tkMessageBox.showerror(title, msg)
 
-    def show_info(self, title, msg):        
-        tkMessageBox.showinfo(title, msg,parent = self.root)
+    def show_info(self, title, msg):
+        tkMessageBox.showinfo(title, msg, parent=self.root)
 
     def show_warning(self, title, msg):
         tkMessageBox.showwarning(title, msg)
@@ -1521,7 +1502,6 @@ class View(utils.SubjectMixin):
         self.unmute('change:text')
         self.unmute('change:tags')
         self.unmute('change:pinned')
-
 
     def update_selected_note_data(self, note):
         """
@@ -1566,7 +1546,6 @@ class View(utils.SubjectMixin):
         # reactivate event handlers
         self.unmute_note_data_changes()
 
-
     def word_count(self):
         """
         Display count of total words and selected words in a dialog box.
@@ -1578,4 +1557,4 @@ class View(utils.SubjectMixin):
         txt = self.get_text()
         tlen = len(txt.split())
 
-        self.show_info('Word Count', '%d words in total\n%d words in selection' % (tlen,slen))
+        self.show_info('Word Count', '%d words in total\n%d words in selection' % (tlen, slen))

--- a/setup.py
+++ b/setup.py
@@ -6,23 +6,25 @@ from nvpy import nvpy
 # Used for the long_description.  It's nice, because now 1) we have a top level
 # README file and 2) it's easier to type in the README file than to put a raw
 # string in below ...
+
+
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(
-    name = "nvpy",
-    version = nvpy.VERSION,
-    author = "Charl P. Botha",
-    author_email = "cpbotha@vxlabs.com",
-    description = "A cross-platform simplenote-syncing note-taking app inspired by Notational Velocity.",
-    license = "BSD",
-    keywords = "simplenote note-taking tkinter nvalt markdown",
-    url = "https://github.com/cpbotha/nvpy",
+    name="nvpy",
+    version=nvpy.VERSION,
+    author="Charl P. Botha",
+    author_email="cpbotha@vxlabs.com",
+    description="A cross-platform simplenote-syncing note-taking app inspired by Notational Velocity.",
+    license="BSD",
+    keywords="simplenote note-taking tkinter nvalt markdown",
+    url="https://github.com/cpbotha/nvpy",
     packages=['nvpy'],
     long_description=read('README.rst'),
-    install_requires = ['Markdown', 'docutils'],
-    entry_points = {
-        'gui_scripts' : ['nvpy = nvpy.nvpy:main']
+    install_requires=['Markdown', 'docutils'],
+    entry_points={
+        'gui_scripts': ['nvpy = nvpy.nvpy:main']
     },
     # use MANIFEST.in file
     # because package_data is ignored during sdist
@@ -36,4 +38,3 @@ setup(
         "License :: OSI Approved :: BSD License",
     ],
 )
-


### PR DESCRIPTION
Fixing PEP8 code style violations (ignoring line length warnings).
I was running `pep8 --ignore=E501` on all files in the repository and
mostly changed whitespace.

"Special" changes
- In [nvpy/nvpy.py]() I also removed some semicolons
- In [nvpy/simplenote.py]() and [nvpy/view.py]() I replaces all
  "foo.has_key(bar)" instances  with "bar in foo", as suggested by
  `pep8`.

As part of http://24pullrequests.com