### PR TITLE
Fix pinned button problem

### DIFF
--- a/nvpy/view.py
+++ b/nvpy/view.py
@@ -1559,9 +1559,9 @@ class View(utils.SubjectMixin):
                     command=lambda tag=tag:
                     self.handler_delete_tag_from_selected_note(tag))
             tag_button.pack(side=tk.LEFT)
-        
-            #self.tags_entry_var.set(','.join(tags))
-            self.pinned_checkbutton_var.set(utils.note_pinned(note))
+
+        #self.tags_entry_var.set(','.join(tags))
+        self.pinned_checkbutton_var.set(utils.note_pinned(note))
 
         if reset_undo:
             # usually when a new note is selected, we want to reset the


### PR DESCRIPTION
Pinned button does not work when selected note don't have any tag.
This bug occurred with 97a56b0bc502f0634caca782bf65d9e2138db723.