### PR TITLE
[Feature]: Define filetypes in config

### DIFF
--- a/nvpy/notes_db.py
+++ b/nvpy/notes_db.py
@@ -57,8 +57,10 @@ class NotesDB(utils.SubjectMixin):
         now = time.time()
         # now read all .json files from disk
         fnlist = glob.glob(self.helper_key_to_fname('*'))
-        txtlist = glob.glob(unicode(self.config.txt_path + '/*.txt', 'utf-8'))
-        txtlist += glob.glob(unicode(self.config.txt_path + '/*.mkdn', 'utf-8'))
+        txtlist = []
+
+        for ext in config.read_txt_extensions.split(','):
+            txtlist += glob.glob(unicode(self.config.txt_path + '/*.' + ext, 'utf-8'))
 
         # removing json files and force full full sync if using text files
         # and none exists and json files are there
@@ -423,7 +425,7 @@ class NotesDB(utils.SubjectMixin):
         o = utils.KeyValueObject(saved=False, synced=False, modified=False, full_syncing=self.full_syncing)
         if key is None:
             return o
-        
+
         n = self.notes[key]
         modifydate = float(n['modifydate'])
         savedate = float(n['savedate'])
@@ -856,7 +858,7 @@ class NotesDB(utils.SubjectMixin):
             n['tags'] = tags
             n['modifydate'] = time.time()
             self.notify_observers('change:note-status', utils.KeyValueObject(what='modifydate', key=key))
-    
+
     def delete_note_tag(self, key, tag):
         note = self.notes[key]
         note_tags = note.get('tags')
@@ -864,7 +866,7 @@ class NotesDB(utils.SubjectMixin):
         note['tags'] = note_tags
         note['modifydate'] = time.time()
         self.notify_observers('change:note-status', utils.KeyValueObject(what='modifydate', key=key))
-    
+
     def add_note_tags(self, key, comma_seperated_tags):
         note = self.notes[key]
         note_tags = note.get('tags')

--- a/nvpy/nvpy-example.cfg
+++ b/nvpy/nvpy-example.cfg
@@ -39,7 +39,7 @@ list_font_size = 10
 layout = horizontal
 
 # if the vertical layout is choosen, this option can be used
-# to print the notelist in columns. 
+# to print the notelist in columns.
 # The list_font_family_fixed will be used
 print_columns = 1
 
@@ -74,6 +74,9 @@ notes_as_txt = 0
 
 # txt notes directory relative to home
 #txt_path = Notes2
+
+# filetypes to read in (comma-separated)
+#read_txt_extensions: txt,mkdn,md,mdown,markdown
 
 # uncomment this to disable simplenote sync altogether
 # default is to sync with simplenote

--- a/nvpy/nvpy.py
+++ b/nvpy/nvpy.py
@@ -92,6 +92,7 @@ class Config:
                     'appdir': app_dir,
                     'home': home,
                     'notes_as_txt': '0',
+                    'read_txt_extensions': 'txt,mkdn,md,mdown,markdown',
                     'housekeeping_interval': '2',
                     'search_mode': 'gstyle',
                     'case_sensitive': '1',
@@ -706,7 +707,7 @@ class Controller:
         key = self.notes_list_model.list[self.selected_note_idx].key
         self.notes_db.delete_note_tag(key, evt.tag)
         self.view.cmd_notes_list_select()
-    
+
     def observer_view_add_tag(self, view, evt_type, evt):
         key = self.notes_list_model.list[self.selected_note_idx].key
         self.notes_db.add_note_tags(key, evt.tags)


### PR DESCRIPTION
This pull request adds support for defining the filetypes nvpy will read in when using `notes_as_txt`. 

My use-case: I have a pretty extensive `notes` folder, built up over years of using various apps (including nvalt) - however, most of the files have `.md` extensions. Therefore, nvpy only read a small subset of my notes (those that had a `.txt` extension).

Now, the `read_txt_extensions` config item will allow the user to define which filetypes they want nvpy to display.