### PR TITLE
Updated install directions for Debian-likes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ A note on automatic syncing
 Installation
 ============
 
-nvPY works best on Python 3.6 or later.  If you want to work on python 2.7, please use nvPY v1.2.x.
+nvPY works only on Python 3.6 or later.  If you want to work on python 2.7, please use nvPY v1.2.x.
 
 To install the latest development version from github, do::
 
@@ -53,12 +53,12 @@ To install the latest development version from github, do::
 
 OR, to install the version currently on pypi, do::
 
-    pip install nvpy
+    pip3 install nvpy
     
 If already have nvpy installed, but you want to upgrade, try the following::
 
-    sudo pip uninstall nvpy
-    sudo pip install --upgrade nvpy
+    sudo pip3 uninstall nvpy
+    sudo pip3 install --upgrade nvpy
 
 OR, you can of course use easy\_install instead::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -50,10 +50,12 @@ To upgrade an existing installation of nvpy, do the following::
 Ubuntu / Mint / Debian step-by-step
 ===================================
 
-On Debian-flavoured systems with apt, this generally works::
+On Debian-flavoured systems with apt, current releases of nypy require Python 3.6 or later. If you are running Debian-buster, Ubuntu-bionic, or later, which have a compatible release of Python as the default for `python3`, this generally works::
 
     sudo apt-get install python3 python3-tk python3-pip
     sudo pip3 install -U nvpy
+
+Older releases may require manual installation of python 3.6 or later. 
 
 Create a file in your home directory called .nvpy.cfg with just the following contents::
 


### PR DESCRIPTION
Updating documentation to clarify current requirements of Python 3.6 as per https://github.com/cpbotha/nvpy/issues/190 . I believe directing users to employ `pip3` is a safe default assumption but feel free to reject if this is problematic for other distros.