### PR TITLE
Split on '\s+' (multiple whitespace) when parsing config file 'md_extensions' setting

### DIFF
--- a/nvpy/nvpy.py
+++ b/nvpy/nvpy.py
@@ -533,7 +533,7 @@ class Controller:
             logging.debug("Trying to convert %s to html." % (key, ))
             if HAVE_MARKDOWN:
                 logging.debug("Convert note %s to html." % (key, ))
-                exts = re.split("\\s", self.config.md_extensions.strip()) if self.config.md_extensions else []
+                exts = re.split('\s+', self.config.md_extensions.strip()) if self.config.md_extensions else []
                 exts += list(DEFAULT_MARKDOWN_EXTS)
                 # remove duplicate items on exts.
                 exts = list(set(exts))


### PR DESCRIPTION
Closes #201.