### PR TITLE
Change behavior of escape key

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,7 +173,7 @@ Ctrl-SPACE    In search box, autocomplete tag under cursor. Keep on pressing for
 Ctrl-+/-      Increase or decrease the font size.
 Ctrl-BS       Delete previous word in the note editor.
 Ctrl-Delete   Delete next word in the note editor.
-ESC           Go from edit mode to search box.
+ESC           Go from edit mode to search box; in empty search box, exit nvPY.
 Ctrl-[        Same as ESC. (VIM binding)
 ENTER         Start editing currently selected note. If there's a search string but no notes in the list, ENTER creates a new note with that search string as its title.
 ============= ==========

--- a/README.rst
+++ b/README.rst
@@ -173,7 +173,7 @@ Ctrl-SPACE    In search box, autocomplete tag under cursor. Keep on pressing for
 Ctrl-+/-      Increase or decrease the font size.
 Ctrl-BS       Delete previous word in the note editor.
 Ctrl-Delete   Delete next word in the note editor.
-ESC           Go from edit mode to notes list.
+ESC           Go from edit mode to search box.
 Ctrl-[        Same as ESC. (VIM binding)
 ENTER         Start editing currently selected note. If there's a search string but no notes in the list, ENTER creates a new note with that search string as its title.
 ============= ==========

--- a/README.rst
+++ b/README.rst
@@ -173,7 +173,7 @@ Ctrl-SPACE    In search box, autocomplete tag under cursor. Keep on pressing for
 Ctrl-+/-      Increase or decrease the font size.
 Ctrl-BS       Delete previous word in the note editor.
 Ctrl-Delete   Delete next word in the note editor.
-ESC           Go from edit mode to search box; in empty search box, exit nvPY.
+ESC           Go from edit mode to search box (and, optionally, in empty search box, exit nvPY).
 Ctrl-[        Same as ESC. (VIM binding)
 ENTER         Start editing currently selected note. If there's a search string but no notes in the list, ENTER creates a new note with that search string as its title.
 ============= ==========

--- a/nvpy/bindings.py
+++ b/nvpy/bindings.py
@@ -26,7 +26,7 @@ Ctrl-SPACE    In search box, autocomplete tag under cursor. Keep on pressing for
 Ctrl-+/-      Increase or decrease the font size.
 Ctrl-BS       Delete previous word in the note editor.
 Ctrl-Delete   Delete next word in the note editor.
-ESC           Go from edit mode to notes list.
+ESC           Go from edit mode to search box.
 Ctrl-[        Same as ESC. (VIM binding)
 ENTER         Start editing currently selected note. If there's a search string but
               no notes in the list, ENTER creates a new note with that search

--- a/nvpy/bindings.py
+++ b/nvpy/bindings.py
@@ -26,7 +26,7 @@ Ctrl-SPACE    In search box, autocomplete tag under cursor. Keep on pressing for
 Ctrl-+/-      Increase or decrease the font size.
 Ctrl-BS       Delete previous word in the note editor.
 Ctrl-Delete   Delete next word in the note editor.
-ESC           Go from edit mode to search box.
+ESC           Go from edit mode to search box; in empty search box, exit nvPY.
 Ctrl-[        Same as ESC. (VIM binding)
 ENTER         Start editing currently selected note. If there's a search string but
               no notes in the list, ENTER creates a new note with that search

--- a/nvpy/bindings.py
+++ b/nvpy/bindings.py
@@ -26,7 +26,7 @@ Ctrl-SPACE    In search box, autocomplete tag under cursor. Keep on pressing for
 Ctrl-+/-      Increase or decrease the font size.
 Ctrl-BS       Delete previous word in the note editor.
 Ctrl-Delete   Delete next word in the note editor.
-ESC           Go from edit mode to search box; in empty search box, exit nvPY.
+ESC           Go from edit mode to search box (and, optionally, in empty search box, exit nvPY).
 Ctrl-[        Same as ESC. (VIM binding)
 ENTER         Start editing currently selected note. If there's a search string but
               no notes in the list, ENTER creates a new note with that search

--- a/nvpy/nvpy-example.cfg
+++ b/nvpy/nvpy-example.cfg
@@ -142,6 +142,10 @@ notes_as_txt = 0
 # default: true
 #confirm_delete = false
 
+# exit by hitting escape when in empty search box
+# default: false
+#escape_to_exit = false
+
 # show exit confirmation dialog
 # default: false
 #confirm_exit = true

--- a/nvpy/nvpy.py
+++ b/nvpy/nvpy.py
@@ -159,6 +159,7 @@ class Config:
             'md_extensions': '',
             'keep_search_keyword': 'false',
             'confirm_delete': 'true',
+            'escape_to_exit': 'false',
             'confirm_exit': 'false',
         }
 
@@ -225,6 +226,7 @@ class Config:
         self.debug = cp.getint(cfg_sec, 'debug')
         self.keep_search_keyword = cp.getboolean(cfg_sec, 'keep_search_keyword')
         self.confirm_delete = cp.getboolean(cfg_sec, 'confirm_delete')
+        self.escape_to_exit = cp.getboolean(cfg_sec, 'escape_to_exit')
         self.confirm_exit = cp.getboolean(cfg_sec, 'confirm_exit')
 
         self.warnings = []

--- a/nvpy/view.py
+++ b/nvpy/view.py
@@ -1710,12 +1710,12 @@ class View(utils.SubjectMixin):
     def handler_search_escape(self, evt):
         # user has pressed escape whilst searching
         # 1. if search box has text in it, delete that text
-        # 2. if search box does not have text in it, quit
+        # 2. if search box does not have text in it and the user has configured escape_to_exit, then quit
 
         if self.get_search_entry_text() != '':
             self.search_entry.delete(0, tk.END)
 
-        else:
+        elif self.config.escape_to_exit:
             self.handler_close()
 
     def handler_search_entry(self, *args):

--- a/nvpy/view.py
+++ b/nvpy/view.py
@@ -1188,8 +1188,8 @@ class View(utils.SubjectMixin):
         self.notes_list.text.bind("<Escape>", lambda e: self.search_entry.focus())
         self.notes_list.text.bind("<Control-bracketleft>", lambda e: self.search_entry.focus())
 
-        self.search_entry.bind("<Escape>", lambda e: self.search_entry.delete(0, tk.END))
-        self.search_entry.bind("<Control-bracketleft>", lambda e: self.search_entry.delete(0, tk.END))
+        self.search_entry.bind("<Escape>", self.handler_search_escape)
+        self.search_entry.bind("<Control-bracketleft>", self.handler_search_escape)
         # this will either focus current content, or
         # if there's no selection, create a new note.
         self.search_entry.bind("<Return>", self.handler_search_enter)
@@ -1706,6 +1706,17 @@ class View(utils.SubjectMixin):
             self.notify_observers('create:note', events.NoteCreatedEvent(title=self.get_search_entry_text()))
             # the note will be created synchronously, so we can focus the text area already
             self.text_note.focus()
+
+    def handler_search_escape(self, evt):
+        # user has pressed escape whilst searching
+        # 1. if search box has text in it, delete that text
+        # 2. if search box does not have text in it, quit
+
+        if self.get_search_entry_text() != '':
+            self.search_entry.delete(0, tk.END)
+
+        else:
+            self.handler_close()
 
     def handler_search_entry(self, *args):
         self.notify_observers('change:entry', events.TextBoxChangedEvent(value=self.search_entry_var.get()))

--- a/nvpy/view.py
+++ b/nvpy/view.py
@@ -1202,9 +1202,9 @@ class View(utils.SubjectMixin):
 
         self.text_note.bind("<<Change>>", self.handler_text_change)
 
-        # user presses escape in text area, they go back to notes list
-        self.text_note.bind("<Escape>", lambda e: self.notes_list.text.focus())
-        self.text_note.bind("<Control-bracketleft>", lambda e: self.notes_list.text.focus())
+        # user presses escape in text area, they go back to search box
+        self.text_note.bind("<Escape>", lambda e: self.search_entry.focus())
+        self.text_note.bind("<Control-bracketleft>", lambda e: self.search_entry.focus())
         # <Key>
 
         self.text_note.bind("<Control-BackSpace>", self.handler_control_backspace)

--- a/nvpy/view.py
+++ b/nvpy/view.py
@@ -1185,6 +1185,8 @@ class View(utils.SubjectMixin):
         # if nothing is selected, try to create new note with
         # search entry value as name
         self.notes_list.text.bind("<Return>", self.handler_search_enter)
+        self.notes_list.text.bind("<Escape>", lambda e: self.search_entry.focus())
+        self.notes_list.text.bind("<Control-bracketleft>", lambda e: self.search_entry.focus())
 
         self.search_entry.bind("<Escape>", lambda e: self.search_entry.delete(0, tk.END))
         self.search_entry.bind("<Control-bracketleft>", lambda e: self.search_entry.delete(0, tk.END))


### PR DESCRIPTION

A person's usual way of using nvPY is to type something in the search box, hit enter, and then edit the resulting note.

At the conclusion of that workflow, the user who hits escape expects to go back to the search box, but nvPY's current behavior is to send the focus to the notes list, where the user becomes trapped, because hitting escape there does nothing.

This pull request changes the behavior of the escape key so that hitting escape when editing a note sends the focus back to the search box.

Additionally, it makes it so that hitting escape when in the notes list also sends the focus back to the search box.

Also: I believe that a common way to use nvPY is to configure one's system so that hitting a hot key brings up nvPY, which allows a person to quickly add notes while working in other applications.

At the conclusion of doing so, when the user is in an empty search box, hitting escape is a natural way to make nvPY go away until needed again.

Therefore, this pull request also creates the "escape_to_exit" option, which can be configured in the .nvpy.cfg file.

It defaults to false, but when set to be true, it makes it so that hitting escape when in an empty search box exits the program.

I believe that all these changes help to keep nvPY even more in the original keyboard-driven and lightning-fast spirit of Notational Velocity.

Thank you for considering these changes.
