### PR TITLE
Streamline interface and add menus

### DIFF
--- a/nvpy/nvpy-example.cfg
+++ b/nvpy/nvpy-example.cfg
@@ -145,3 +145,7 @@ notes_as_txt = 0
 # show exit confirmation dialog
 # default: false
 #confirm_exit = true
+
+# streameline interface by omitting certain elements
+# default: false
+#streamline_interface = false

--- a/nvpy/nvpy.py
+++ b/nvpy/nvpy.py
@@ -160,6 +160,7 @@ class Config:
             'keep_search_keyword': 'false',
             'confirm_delete': 'true',
             'confirm_exit': 'false',
+            'streamline_interface': 'false',
         }
 
         self.files_read, cp = self._load_cfg(defaults, cfg)
@@ -226,6 +227,8 @@ class Config:
         self.keep_search_keyword = cp.getboolean(cfg_sec, 'keep_search_keyword')
         self.confirm_delete = cp.getboolean(cfg_sec, 'confirm_delete')
         self.confirm_exit = cp.getboolean(cfg_sec, 'confirm_exit')
+
+        self.streamline_interface = cp.getboolean(cfg_sec, 'streamline_interface')
 
         self.warnings = []
         if cp.has_option(cfg_sec, 'background_full_sync'):

--- a/nvpy/view.py
+++ b/nvpy/view.py
@@ -1309,9 +1309,19 @@ class View(utils.SubjectMixin):
                               command=lambda: self.search_entry.focus())
         self.root.bind_all("<Control-f>", self.search)
 
+        # NOTE #########################################################
+        note_menu = tk.Menu(menu, tearoff=False)
+        menu.add_cascade(label='Note', underline=0, menu=note_menu)
+
+        self.pinned_checkbutton_var = tk.IntVar()
+        note_menu.add_checkbutton(label='Pinned',
+                                   onvalue=1,
+                                   offvalue=0,
+                                   variable=self.pinned_checkbutton_var)
+
         # NOTES ########################################################
         notes_menu = tk.Menu(menu, tearoff=False)
-        menu.add_cascade(label='Notes', underline=0, menu=notes_menu)
+        menu.add_cascade(label='Notes', underline=1, menu=notes_menu)
 
         self.sort_mode_var = tk.StringVar()
         for mode in self.sort_modes:
@@ -1508,7 +1518,7 @@ class View(utils.SubjectMixin):
         pinned_label = tk.Label(note_pinned_frame, text="Pinned")
         if not self.config.streamline_interface:
             pinned_label.pack(side=tk.LEFT)
-        self.pinned_checkbutton_var = tk.IntVar()
+        # self.pinned_checkbutton_var = tk.IntVar() # Moved to note menu code area
         self.pinned_checkbutton = tk.Checkbutton(note_pinned_frame, variable=self.pinned_checkbutton_var)
         if not self.config.streamline_interface:
             self.pinned_checkbutton.pack(side=tk.LEFT)

--- a/nvpy/view.py
+++ b/nvpy/view.py
@@ -1324,6 +1324,25 @@ class View(utils.SubjectMixin):
                                    offvalue=False,
                                    variable=self.pinned_on_top_var)
 
+        # SEARCH #######################################################
+        search_menu = tk.Menu(menu, tearoff=False)
+        menu.add_cascade(label='Search', underline=0, menu=search_menu)
+
+        self.search_mode_options = ("gstyle", "regexp")
+        self.search_mode_var = tk.StringVar()
+
+        for mode in self.search_mode_options:
+            search_menu.add_radiobutton(label=f'Search mode {mode}', value=mode, variable=self.search_mode_var)
+
+        search_menu.add_separator()
+
+        self.cs_checkbutton_var = tk.IntVar()
+
+        search_menu.add_checkbutton(label='Case sensitive',
+                                   onvalue=1,
+                                   offvalue=0,
+                                   variable=self.cs_checkbutton_var)
+
         # TOOLS ########################################################
         tools_menu = tk.Menu(menu, tearoff=False)
         menu.add_cascade(label="Tools", underline=0, menu=tools_menu)
@@ -1404,11 +1423,11 @@ class View(utils.SubjectMixin):
                                                    style="Search.entry")
 
         cs_label = tk.Label(search_frame, text="CS ")
-        self.cs_checkbutton_var = tk.IntVar()
+        # self.cs_checkbutton_var = tk.IntVar() # Moved to search menu code area
         cs_checkbutton = tk.Checkbutton(search_frame, variable=self.cs_checkbutton_var)
 
-        self.search_mode_options = ("gstyle", "regexp")
-        self.search_mode_var = tk.StringVar()
+        # self.search_mode_options = ("gstyle", "regexp") # Moved to search menu code area
+        # self.search_mode_var = tk.StringVar()
         # I'm working with ttk.OptionVar, which has that extra default param!
         self.search_mode_cb = tk.OptionMenu(search_frame, self.search_mode_var, self.search_mode_options[0],
                                             *self.search_mode_options)

--- a/nvpy/view.py
+++ b/nvpy/view.py
@@ -1414,9 +1414,10 @@ class View(utils.SubjectMixin):
                                             *self.search_mode_options)
         self.search_mode_cb.config(width=6)
 
-        # GH # self.search_mode_cb.pack(side=tk.RIGHT, padx=5)
-        # GH # cs_checkbutton.pack(side=tk.RIGHT)
-        # GH # cs_label.pack(side=tk.RIGHT)
+        if not self.config.streamline_interface:
+            self.search_mode_cb.pack(side=tk.RIGHT, padx=5)
+            cs_checkbutton.pack(side=tk.RIGHT)
+            cs_label.pack(side=tk.RIGHT)
         self.search_entry.pack(fill=tk.X, padx=5, pady=5)
 
         search_frame.pack(side=tk.TOP, fill=tk.X)
@@ -1448,12 +1449,15 @@ class View(utils.SubjectMixin):
             self.notes_list.pack(fill=tk.BOTH, expand=1)
 
             sort_mode_frame = tk.Frame(list_frame)
-            # GH # sort_mode_frame.pack(side=tk.TOP, fill=tk.X)
+            if not self.config.streamline_interface:
+                sort_mode_frame.pack(side=tk.TOP, fill=tk.X)
             sort_mode_label = tk.Label(sort_mode_frame, text='Sort by')
-            # GH # sort_mode_label.pack(side=tk.LEFT)
+            if not self.config.streamline_interface:
+                sort_mode_label.pack(side=tk.LEFT)
             sort_mode_selector = tk.OptionMenu(sort_mode_frame, self.sort_mode_var, self.sort_modes[0],
                                                *self.sort_modes)
-            # GH # sort_mode_selector.pack(side=tk.LEFT, fill=tk.X, expand=1)
+            if not self.config.streamline_interface:
+                sort_mode_selector.pack(side=tk.LEFT, fill=tk.X, expand=1)
 
             note_frame = tk.Frame(paned_window, width=400)
 
@@ -1479,19 +1483,24 @@ class View(utils.SubjectMixin):
         paned_window.add(note_frame)
 
         note_pinned_frame = tk.Frame(note_frame)
-        # GH # note_pinned_frame.pack(side=tk.BOTTOM, fill=tk.X)
+        if not self.config.streamline_interface:
+            note_pinned_frame.pack(side=tk.BOTTOM, fill=tk.X)
 
         pinned_label = tk.Label(note_pinned_frame, text="Pinned")
-        # GH # pinned_label.pack(side=tk.LEFT)
+        if not self.config.streamline_interface:
+            pinned_label.pack(side=tk.LEFT)
         self.pinned_checkbutton_var = tk.IntVar()
         self.pinned_checkbutton = tk.Checkbutton(note_pinned_frame, variable=self.pinned_checkbutton_var)
-        # GH # self.pinned_checkbutton.pack(side=tk.LEFT)
+        if not self.config.streamline_interface:
+            self.pinned_checkbutton.pack(side=tk.LEFT)
 
         note_tags_frame = tk.Frame(note_pinned_frame)
-        # GH # note_tags_frame.pack(side=tk.LEFT)
+        if not self.config.streamline_interface:
+            note_tags_frame.pack(side=tk.LEFT)
 
         tags_label = tk.Label(note_tags_frame, text="Add Tags")
-        # GH # tags_label.pack(side=tk.LEFT)
+        if not self.config.streamline_interface:
+            tags_label.pack(side=tk.LEFT)
 
         def completion_func(searchWord):
             if self.taglist is None:

--- a/nvpy/view.py
+++ b/nvpy/view.py
@@ -1414,9 +1414,9 @@ class View(utils.SubjectMixin):
                                             *self.search_mode_options)
         self.search_mode_cb.config(width=6)
 
-        self.search_mode_cb.pack(side=tk.RIGHT, padx=5)
-        cs_checkbutton.pack(side=tk.RIGHT)
-        cs_label.pack(side=tk.RIGHT)
+        # GH # self.search_mode_cb.pack(side=tk.RIGHT, padx=5)
+        # GH # cs_checkbutton.pack(side=tk.RIGHT)
+        # GH # cs_label.pack(side=tk.RIGHT)
         self.search_entry.pack(fill=tk.X, padx=5, pady=5)
 
         search_frame.pack(side=tk.TOP, fill=tk.X)
@@ -1448,12 +1448,12 @@ class View(utils.SubjectMixin):
             self.notes_list.pack(fill=tk.BOTH, expand=1)
 
             sort_mode_frame = tk.Frame(list_frame)
-            sort_mode_frame.pack(side=tk.TOP, fill=tk.X)
+            # GH # sort_mode_frame.pack(side=tk.TOP, fill=tk.X)
             sort_mode_label = tk.Label(sort_mode_frame, text='Sort by')
-            sort_mode_label.pack(side=tk.LEFT)
+            # GH # sort_mode_label.pack(side=tk.LEFT)
             sort_mode_selector = tk.OptionMenu(sort_mode_frame, self.sort_mode_var, self.sort_modes[0],
                                                *self.sort_modes)
-            sort_mode_selector.pack(side=tk.LEFT, fill=tk.X, expand=1)
+            # GH # sort_mode_selector.pack(side=tk.LEFT, fill=tk.X, expand=1)
 
             note_frame = tk.Frame(paned_window, width=400)
 
@@ -1479,19 +1479,19 @@ class View(utils.SubjectMixin):
         paned_window.add(note_frame)
 
         note_pinned_frame = tk.Frame(note_frame)
-        note_pinned_frame.pack(side=tk.BOTTOM, fill=tk.X)
+        # GH # note_pinned_frame.pack(side=tk.BOTTOM, fill=tk.X)
 
         pinned_label = tk.Label(note_pinned_frame, text="Pinned")
-        pinned_label.pack(side=tk.LEFT)
+        # GH # pinned_label.pack(side=tk.LEFT)
         self.pinned_checkbutton_var = tk.IntVar()
         self.pinned_checkbutton = tk.Checkbutton(note_pinned_frame, variable=self.pinned_checkbutton_var)
-        self.pinned_checkbutton.pack(side=tk.LEFT)
+        # GH # self.pinned_checkbutton.pack(side=tk.LEFT)
 
         note_tags_frame = tk.Frame(note_pinned_frame)
-        note_tags_frame.pack(side=tk.LEFT)
+        # GH # note_tags_frame.pack(side=tk.LEFT)
 
         tags_label = tk.Label(note_tags_frame, text="Add Tags")
-        tags_label.pack(side=tk.LEFT)
+        # GH # tags_label.pack(side=tk.LEFT)
 
         def completion_func(searchWord):
             if self.taglist is None:


### PR DESCRIPTION

Right now, hitting tab when in the search box sends the focus first to the "CS" checkbox, then to the search-style dropdown, then to the sort-by dropdown, then to the "pinned" checkbox, then to the add-tags tool—and only then to the selected note.

Hitting shift+tab sends the user backwards along the same long path.

All these stops along the way in the tab order are rarely used options that keep the user from quickly tabbing between the search box and the selected note.

These rarely used options also contribute to nvPY's alleged ugliness by cluttering up the interface, contrary to the spirit of the original Notational Velocity.

Therefore, this pull request creates a streamline_interface option that can be set in .nvpy.cfg.

It defaults to false, but when set to be true, it prevents the "CS" checkbox, the search-style dropdown, the sort-by dropdown, the "pinned" checkbox, and the add-tags tool all from being rendered. This takes those options out of the tab order and allows the user to quickly tab between the search box and the selected note. Having this option will be appealing to a user who doesn't use those features.

Additionally, this pull request creates a new "Note" menu (to allow the user to set a note as being pinned) and a "Search" menu (to allow the user to set the search mode options).

Thank you for considering these changes.
