### PR TITLE
Add option to disable underlining of URLs

### DIFF
--- a/nvpy/nvpy-example.cfg
+++ b/nvpy/nvpy-example.cfg
@@ -36,6 +36,10 @@ list_font_size = 10
 #list_hide_time = 1
 #list_hide_tags = 1
 
+# Underline URLs in notes
+# default: true
+# underline_urls = true
+
 # UI layout
 # horizontal: notes list on the left, current note on the right
 # vertical: notes list full width at the top, current note below that

--- a/nvpy/nvpy.py
+++ b/nvpy/nvpy.py
@@ -138,6 +138,7 @@ class Config:
             'list_font_size': '10',
             'list_hide_time': '0',
             'list_hide_tags': '0',
+            'underline_urls': 'true',
             'layout': 'horizontal',
             'print_columns': '0',
             'text_color': 'black',
@@ -206,6 +207,8 @@ class Config:
 
         self.list_hide_time = cp.getint(cfg_sec, 'list_hide_time')
         self.list_hide_tags = cp.getint(cfg_sec, 'list_hide_tags')
+
+        self.underline_urls = cp.getboolean(cfg_sec, 'underline_urls')
 
         self.layout = cp.get(cfg_sec, 'layout')
         self.print_columns = cp.getint(cfg_sec, 'print_columns')

--- a/nvpy/view.py
+++ b/nvpy/view.py
@@ -1851,6 +1851,9 @@ class View(utils.SubjectMixin):
                 link = list(filter(None, mo.groups()))[0]
                 ul = 1
 
+            # Disable underline if user chooses to
+            ul = 0 if not self.config.underline_urls else ul
+
             # Create a new Tkinter Tag
             tag = 'web-%d' % (len(self.text_tags_links), )
             t.tag_config(tag,


### PR DESCRIPTION
Underlined URLs add a lot of visual clutter.

This PR adds `underline_urls` configuration option which is set to `true` by default.